### PR TITLE
Expose WPF / WinForms extension methods for WebViewControlProcess

### DIFF
--- a/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebViewControlProcessExtensions.cs
+++ b/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebViewControlProcessExtensions.cs
@@ -13,13 +13,17 @@
 using System;
 using System.Drawing;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT;
 using Windows.Foundation;
 using WebViewControlProcess = Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT.WebViewControlProcess;
 
 namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
 {
-    internal static class WebViewControlProcessExtensions
+    /// <summary>
+    /// Extends the funcionality of <see cref="WebViewControlProcess"/> for Windows Forms.
+    /// </summary>
+    public static class WebViewControlProcessExtensions
     {
         /// <summary>
         /// Creates a <see cref="IWebView" /> within the context of <paramref name="process" />.
@@ -54,6 +58,46 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
         /// Creates a <see cref="IWebView" /> within the context of <paramref name="process" />.
         /// </summary>
         /// <param name="process">An instance of <see cref="WebViewControlProcess" />.</param>
+        /// <param name="control">An instance of <see cref="Control"/> to parent the <see cref="WebView"/>.</param>
+        /// <returns>An <see cref="IWebView"/> instance.</returns>
+        /// <exception cref="ArgumentNullException">Occurs when <paramref name="control"/> is <see langword="null" />.</exception>
+        public static IWebView CreateWebView(
+            this WebViewControlProcess process,
+            Control control)
+        {
+            if (control == null)
+            {
+                throw new ArgumentNullException(nameof(control));
+            }
+
+            return process.CreateWebView(control, control.Bounds);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IWebView" /> within the context of <paramref name="process" />.
+        /// </summary>
+        /// <param name="process">An instance of <see cref="WebViewControlProcess" />.</param>
+        /// <param name="control">An instance of <see cref="Control"/> to parent the <see cref="WebView"/>.</param>
+        /// <param name="bounds">A <see cref="Rectangle" /> containing numerical values that represent the location and size of the control.</param>
+        /// <returns>An <see cref="IWebView"/> instance.</returns>
+        /// <exception cref="ArgumentNullException">Occurs when <paramref name="control"/> is <see langword="null" />.</exception>
+        public static IWebView CreateWebView(
+            this WebViewControlProcess process,
+            Control control,
+            Rectangle bounds)
+        {
+            if (control == null)
+            {
+                throw new ArgumentNullException(nameof(control));
+            }
+
+            return process.CreateWebView(control.Handle, bounds);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IWebView" /> within the context of <paramref name="process" />.
+        /// </summary>
+        /// <param name="process">An instance of <see cref="WebViewControlProcess" />.</param>
         /// <param name="hostWindowHandle">The parent window handle hosting the control.</param>
         /// <param name="bounds">A <see cref="Rectangle" /> containing numerical values that represent the location and size of the control.</param>
         /// <returns>An <see cref="IWebView" /> instance.</returns>
@@ -77,6 +121,48 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
             }
 
             return new WebView(await process.CreateWebViewControlHostAsync(hostWindowHandle, bounds).ConfigureAwait(false));
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IWebView" /> within the context of <paramref name="process" />.
+        /// </summary>
+        /// <param name="process">An instance of <see cref="WebViewControlProcess" />.</param>
+        /// <param name="control">An instance of <see cref="Control"/> to parent the <see cref="WebView"/>.</param>
+        /// <returns>An <see cref="IWebView"/> instance.</returns>
+        /// <exception cref="ArgumentNullException">Occurs when <paramref name="control"/> is <see langword="null" />.</exception>
+        public static Task<IWebView> CreateWebViewAsync(
+            this WebViewControlProcess process,
+            Control control)
+        {
+            if (control == null)
+            {
+                throw new ArgumentNullException(nameof(control));
+            }
+
+            return process.CreateWebViewAsync(control, control.Bounds);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IWebView" /> within the context of <paramref name="process" />.
+        /// </summary>
+        /// <param name="process">An instance of <see cref="WebViewControlProcess" />.</param>
+        /// <param name="control">An instance of <see cref="Control"/> to parent the <see cref="WebView"/>.</param>
+        /// <param name="bounds">A <see cref="Rectangle" /> containing numerical values that represent the location and size of the control.</param>
+        /// <returns>An <see cref="IWebView"/> instance.</returns>
+        /// <exception cref="ArgumentNullException">Occurs when <paramref name="control"/> is <see langword="null" />.</exception>
+        public static async Task<IWebView> CreateWebViewAsync(
+            this WebViewControlProcess process,
+            Control control,
+            Rectangle bounds)
+        {
+            if (control == null)
+            {
+                throw new ArgumentNullException(nameof(control));
+            }
+
+            var webViewControl = await process.CreateWebViewAsync(control.Handle, bounds).ConfigureAwait(false);
+            control.Controls.Add((Control)webViewControl);
+            return webViewControl;
         }
 
         /// <summary>


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Users will see samples and guidance for UWP version of `WebViewControl` and are not able to translate that into something actionable in their WPF or Windows Forms application.

For example, users may see usage syntax like the following
```csharp
private async void button1_Click(object sender, EventArgs e)
{
  var rect = new Rect(0, 0, panel1.Width, panel1.Height);
  var wvcp = new WebViewControlProcess();
  var wvc = await wvcp.CreateWebViewControlAsync(panel1.Handle.ToInt64(), rect);
  wvc.Navigate(new Uri("https://www.microsoft.com"));
}
```
Similar methods required to achieve this syntax for Windows Forms and WPF are not available.

## What is the new behavior?
Change the visibility of extension methods for `WebViewControlProcess` proxy making it easy to adapt existing documentation for `WebViewControl` and implement similar functionality for Windows Forms and WPF applications.

**WinForms**

_Code seen in UWP samples with minor changes_
```csharp
private async void button1_Click(object sender, EventArgs e)
{
  var rect = panel1.Bounds;
  var wvcp = new WebViewControlProcess();
  var wvc = await wvcp.CreateWebViewAsync(panel1.Handle, rect);
  panel1.Controls.Add(wvc);
  wvc.Navigate(new Uri("https://www.microsoft.com"));
}
```

_Code taking advantage of new helpers_
```csharp
private async void button1_Click(object sender, EventArgs e)
{
  var wvcp = new WebViewControlProcess();
  var wvc = await wvcp.CreateWebViewAsync(panel1);
  wvc.Navigate(new Uri("https://www.microsoft.com"));
}
```
The new APIs have similar names, but are specific to the toolkit version:
 - `CreateWebViewControlAsync` -> `CreateWebViewAsync` with various overloads.
 - Instead of passing an `Int64` for the handle, a `IntPtr` is used. Instead of directly specifying the HWND, it can be inferred from a `Control`.
 - No need to create a `Rect`, the `System.Drawing.Rectangle` can be used. If using the overload specifying a `Control` as a parameter, this can be omitted and the `Control.Bounds` will be used.

_Note: When specifying a `Control` instance, the `WebView` is automatically added as a child._

**WPF**

```csharp
private async void button1_Click(object sender, RoutedEventArgs e)
{
  var wvcp = new WebViewControlProcess();
  var wvc = await wvcp.CreateWebViewAsync(Window.GetWindow(this));
  wvc.Navigate(new Uri("https://www.microsoft.com"));
}
```
The new APIs have similar names, but are specific to the toolkit version and WPF:
- `CreateWebViewControlAsync` -> `CreateWebViewAsync` with various overloads.
- Instead of passing an `Int64` for the handle, the handle can be inferred from a WPF `Visual`, either the Window (as in the example above), or another element.
- Overloads of `CreateWebViewAsync` exist to pass in a `Rect` specifying the bounds to draw the `WebView` instance. Overloads without take the `Visual.ActualHeight` and `Visual.ActualWidth` as the initial bounds at `{0, 0}` location. The actual size is adjusted after WPF performs a layout and measure.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
This functionality is only made public and is how some functional tests already operate (so no need to write additional tests).
