### PR TITLE
Make WebViewProcessExtensions internal

### DIFF
--- a/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebViewControlProcessExtensions.cs
+++ b/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebViewControlProcessExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
     /// <summary>
     /// Extends the funcionality of <see cref="WebViewControlProcess"/> for WPF.
     /// </summary>
-    public static class WebViewControlProcessExtensions
+    internal static class WebViewControlProcessExtensions
     {
         /// <summary>
         /// Creates a <see cref="IWebView"/> within the context of <paramref name="process"/>.
@@ -36,7 +36,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         /// <paramref name="hostWindowHandle"/> is equal to <see cref="IntPtr.Zero"/>, or
         /// <paramref name="process"/> is <see langword="null" />.
         /// </exception>
-        public static IWebView CreateWebView(
+        internal static IWebView CreateWebView(
             this WebViewControlProcess process,
             IntPtr hostWindowHandle,
             Rect bounds)
@@ -61,7 +61,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         /// <param name="visual">A <see cref="Visual"/> instance in which to create a HWND.</param>
         /// <param name="bounds">A <see cref="Rect" /> containing numerical values that represent the location and size of the control.</param>
         /// <returns>An <see cref="IWebView"/> instance.</returns>
-        public static IWebView CreateWebView(this WebViewControlProcess process, Visual visual, Rect bounds)
+        internal static IWebView CreateWebView(this WebViewControlProcess process, Visual visual, Rect bounds)
         {
             return visual.Dispatcher.Invoke(() => process.CreateWebViewAsync(visual, bounds).GetAwaiter().GetResult());
         }
@@ -76,7 +76,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         /// The bounds to draw the <see cref="WebView"/> are determined by the height and width of the <paramref name="visual"/>.
         /// </remarks>
         /// <seealso cref="CreateWebViewAsync(WebViewControlProcess,IntPtr,Rect)"/>
-        public static IWebView CreateWebView(this WebViewControlProcess process, Visual visual)
+        internal static IWebView CreateWebView(this WebViewControlProcess process, Visual visual)
         {
             return visual.Dispatcher.Invoke(() => process.CreateWebViewAsync(visual).GetAwaiter().GetResult());
         }
@@ -92,7 +92,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         /// <paramref name="hostWindowHandle"/> is equal to <see cref="IntPtr.Zero"/>, or
         /// <paramref name="process"/> is <see langword="null" />.
         /// </exception>
-        public static async Task<IWebView> CreateWebViewAsync(
+        internal static async Task<IWebView> CreateWebViewAsync(
             this WebViewControlProcess process,
             IntPtr hostWindowHandle,
             Rect bounds)
@@ -117,7 +117,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         /// <param name="visual">A <see cref="Visual"/> instance in which to create a HWND.</param>
         /// <param name="bounds">A <see cref="Rect" /> containing numerical values that represent the location and size of the control.</param>
         /// <returns>An asynchronous operation that completes with a <see cref="IWebView"/>.</returns>
-        public static async Task<IWebView> CreateWebViewAsync(this WebViewControlProcess process, Visual visual, Rect bounds)
+        internal static async Task<IWebView> CreateWebViewAsync(this WebViewControlProcess process, Visual visual, Rect bounds)
         {
             HwndSource sourceHwnd;
             if (!visual.Dispatcher.CheckAccess())
@@ -148,7 +148,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         /// The bounds to draw the <see cref="WebView"/> are determined by the height and width of the <paramref name="visual"/>.
         /// </remarks>
         /// <seealso cref="CreateWebViewAsync(WebViewControlProcess,IntPtr,Rect)"/>
-        public static Task<IWebView> CreateWebViewAsync(this WebViewControlProcess process, Visual visual)
+        internal static Task<IWebView> CreateWebViewAsync(this WebViewControlProcess process, Visual visual)
         {
             double width;
             double height;

--- a/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebViewControlProcessExtensions.cs
+++ b/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebViewControlProcessExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
     /// <summary>
     /// Extends the funcionality of <see cref="WebViewControlProcess"/> for Windows Forms.
     /// </summary>
-    public static class WebViewControlProcessExtensions
+    internal static class WebViewControlProcessExtensions
     {
         /// <summary>
         /// Creates a <see cref="IWebView" /> within the context of <paramref name="process" />.
@@ -36,7 +36,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
         /// <paramref name="hostWindowHandle"/> is equal to <see cref="IntPtr.Zero"/>, or
         /// <paramref name="process"/> is <see langword="null" />.
         /// </exception>
-        public static IWebView CreateWebView(
+        internal static IWebView CreateWebView(
             this WebViewControlProcess process,
             IntPtr hostWindowHandle,
             Rectangle bounds)
@@ -61,7 +61,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
         /// <param name="control">An instance of <see cref="Control"/> to parent the <see cref="WebView"/>.</param>
         /// <returns>An <see cref="IWebView"/> instance.</returns>
         /// <exception cref="ArgumentNullException">Occurs when <paramref name="control"/> is <see langword="null" />.</exception>
-        public static IWebView CreateWebView(
+        internal static IWebView CreateWebView(
             this WebViewControlProcess process,
             Control control)
         {
@@ -81,7 +81,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
         /// <param name="bounds">A <see cref="Rectangle" /> containing numerical values that represent the location and size of the control.</param>
         /// <returns>An <see cref="IWebView"/> instance.</returns>
         /// <exception cref="ArgumentNullException">Occurs when <paramref name="control"/> is <see langword="null" />.</exception>
-        public static IWebView CreateWebView(
+        internal static IWebView CreateWebView(
             this WebViewControlProcess process,
             Control control,
             Rectangle bounds)
@@ -105,7 +105,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
         /// <paramref name="hostWindowHandle"/> is equal to <see cref="IntPtr.Zero"/>, or
         /// <paramref name="process"/> is <see langword="null" />.
         /// </exception>
-        public static async Task<IWebView> CreateWebViewAsync(
+        internal static async Task<IWebView> CreateWebViewAsync(
             this WebViewControlProcess process,
             IntPtr hostWindowHandle,
             Rectangle bounds)
@@ -130,7 +130,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
         /// <param name="control">An instance of <see cref="Control"/> to parent the <see cref="WebView"/>.</param>
         /// <returns>An <see cref="IWebView"/> instance.</returns>
         /// <exception cref="ArgumentNullException">Occurs when <paramref name="control"/> is <see langword="null" />.</exception>
-        public static Task<IWebView> CreateWebViewAsync(
+        internal static Task<IWebView> CreateWebViewAsync(
             this WebViewControlProcess process,
             Control control)
         {
@@ -150,7 +150,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
         /// <param name="bounds">A <see cref="Rectangle" /> containing numerical values that represent the location and size of the control.</param>
         /// <returns>An <see cref="IWebView"/> instance.</returns>
         /// <exception cref="ArgumentNullException">Occurs when <paramref name="control"/> is <see langword="null" />.</exception>
-        public static async Task<IWebView> CreateWebViewAsync(
+        internal static async Task<IWebView> CreateWebViewAsync(
             this WebViewControlProcess process,
             Control control,
             Rectangle bounds)


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Users utilizing the extension methods to achieve UWP-style syntax may encounter various issues with parenting the HWNDs depending on when, how, and what the control is parented to (for example, it is fine to do synchronously in WinForms after `InitializeComponent()` but the same cannot be achieved in WPF since the program is not STA).

## What is the new behavior?
Temporarily change the extensions from `public` to `internal` until bugs can be resolved with parenting. This will force users to use the designer experiences which have much higher success in activation.



## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information


The extension methods have not yet shipped, so their removal should not be considered a breaking change. They will be reintroduced when each scenario is validated and documented with its limitations.
