### PR TITLE
Fix issue with Windows Forms WebView control RECT on resize

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/Microsoft/UWPCommunityToolkit/master/build/nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Microsoft/UWPCommunityToolkit</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/Microsoft/UWPCommunityToolkit/blob/master/license.md</PackageLicenseUrl>
-    <PackageReleaseNotes>v2.0: https://github.com/Microsoft/UWPCommunityToolkit/releases/tag/v2.0.0 </PackageReleaseNotes>
+    <PackageReleaseNotes>Preview release of v3.0</PackageReleaseNotes>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 
 

--- a/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.cs
+++ b/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.cs
@@ -449,7 +449,11 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
                 // Ensure that the affected property is the Bounds property to the control
                 if (e.AffectedProperty == nameof(Bounds))
                 {
-                    UpdateBounds(Bounds);
+                    // In a typical control the DisplayRectangle is the interior canvas of the control
+                    // and in a scrolling control the DisplayRectangle would be larger than the ClientRectangle.
+                    // However, that is abstracted from us in WebView so we need to synchronize the ClientRectangle
+                    // and permit WebView to handle scrolling based on the new viewport
+                    UpdateBounds(ClientRectangle);
                 }
             }
         }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-preview-build.{height}",
+  "version": "3.0.0-preview",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/dev$", // we release out of dev


### PR DESCRIPTION
Resolves Issue: #2075
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When control layout is updated, the position of the HWND RECT is incorrect, creating a gap in the layout of the sample application.

## What is the new behavior?
The layout passed the raw Bounds of the control that was not corrected for the offset of the Client RECT.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
