### PR TITLE
MarkdownTextBlock Code Block Scrolling Fix

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Blocks.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Blocks.cs
@@ -12,9 +12,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Microsoft.Toolkit.Parsers.Markdown.Blocks;
 using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Render;
+using Microsoft.Toolkit.Uwp.UI.Extensions;
 using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -328,6 +330,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
                 LineHeight = FontSize * 1.4
             };
 
+            textBlock.PointerWheelChanged += TextBlock_PointerWheelChanged;
+
             var paragraph = new Paragraph();
             textBlock.Blocks.Add(paragraph);
 
@@ -360,6 +364,29 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
             // Add it to the blocks
             blockUIElementCollection.Add(viewer);
         }
+
+        private void TextBlock_PointerWheelChanged(object sender, Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
+        {
+            var pointerPoint = e.GetCurrentPoint((UIElement)sender);
+
+            if (pointerPoint.Properties.IsHorizontalMouseWheel)
+            {
+                e.Handled = false;
+                return;
+            }
+
+            var rootViewer = VisualTree.FindAscendant<ScrollViewer>(RootElement);
+            if (rootViewer != null)
+            {
+                wheelevent?.Invoke(rootViewer, new object[] { e });
+                e.Handled = true;
+            }
+        }
+
+        /// <summary>
+        /// Super Hack to retain inertia and passing the Scroll data onto the Parent ScrollViewer.
+        /// </summary>
+        private MethodInfo wheelevent = typeof(ScrollViewer).GetMethod("OnPointerWheelChanged", BindingFlags.NonPublic | BindingFlags.Instance);
 
         /// <summary>
         /// Renders a table element.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Properties.cs
@@ -12,6 +12,7 @@
 
 using Windows.Foundation.Metadata;
 using Windows.UI.Text;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
@@ -25,6 +26,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
 
         private static bool TextDecorationsSupported => (bool)(_textDecorationsSupported ??
                         (_textDecorationsSupported = ApiInformation.IsTypePresent("Windows.UI.Text.TextDecorations")));
+
+        /// <summary>
+        /// Gets or sets the Root Framework Element.
+        /// </summary>
+        private FrameworkElement RootElement { get; set; }
 
         /// <summary>
         /// Gets the interface that is used to register hyperlinks.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
         public UIElement Render()
         {
             var stackPanel = new StackPanel();
+            RootElement = stackPanel;
             Render(new UIElementCollectionRenderContext(stackPanel.Children) { Foreground = Foreground });
 
             // Set background and border properties.


### PR DESCRIPTION
Added Scroll Hack to return Scrolling Inertia to the Parent ScrollViewer if it exists so that Code Blocks don't steal scroll.

Issue: #1881

## PR Type
What kind of change does this PR introduce?

- Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A Code Block ScrollViewer steals the Mouse Scroll Wheel from a Parent ScrollViewer outside of the MarkdownTextBlock, when the mouse cursor is over a Code Block.

## What is the new behavior?

Violating fundamental concepts of C# to maintain scrolling inertia and prevent visible jankiness.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes, eh.....


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
The Usability of the MarkdownTextBlock is improved, but the interaction is different (For the better).
