### PR TITLE
[Twitter service] support for 280 characters on non streaming api calls

### DIFF
--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/Tweet.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/Tweet.cs
@@ -52,12 +52,6 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         }
 
         /// <summary>
-        /// Gets or sets text of the tweet (280 characters).
-        /// </summary>
-        [JsonProperty("full_text")]
-        public string FullText { get; set; }
-
-        /// <summary>
         /// Gets or sets the extended mode.
         /// </summary>
         [JsonProperty("extended_tweet")]
@@ -97,5 +91,11 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
                 return dt;
             }
         }
+
+        /// <summary>
+        /// Gets or sets text of the tweet (280 characters).
+        /// </summary>
+        [JsonProperty("full_text")]
+        private string FullText { get; set; }
     }
 }

--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/Tweet.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/Tweet.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
     /// </summary>
     public class Tweet : Toolkit.Parsers.SchemaBase, ITwitterResult
     {
+        private string _text;
+
         /// <summary>
         /// Gets or sets time item was created.
         /// </summary>
@@ -40,10 +42,20 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         public string Id { get; set; }
 
         /// <summary>
-        /// Gets or sets text of the tweet (140 characters).
+        /// Gets or sets text of the tweet (handles both 140 and 280 characters)
         /// </summary>
         [JsonProperty("text")]
-        public string Text { get; set; }
+        public string Text
+        {
+            get { return _text ?? FullText; }
+            set { _text = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets text of the tweet (280 characters).
+        /// </summary>
+        [JsonProperty("full_text")]
+        public string FullText { get; set; }
 
         /// <summary>
         /// Gets or sets the extended mode.

--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/Tweet.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/Tweet.cs
@@ -76,6 +76,12 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         public TwitterEntities Entities { get; set; }
 
         /// <summary>
+        /// Gets or sets the Retweeted Tweet
+        /// </summary>
+        [JsonProperty("retweeted_status")]
+        public Tweet RetweetedStatus { get; set; }
+
+        /// <summary>
         /// Gets the creation date
         /// </summary>
         public DateTime CreationDate

--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterDataProvider.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterDataProvider.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
             string rawResult = null;
             try
             {
-                var uri = new Uri($"{BaseUrl}/statuses/user_timeline.json?screen_name={screenName}&count={maxRecords}&include_rts=1");
+                var uri = new Uri($"{BaseUrl}/statuses/user_timeline.json?screen_name={screenName}&count={maxRecords}&include_rts=1&tweet_mode=extended");
 
                 TwitterOAuthRequest request = new TwitterOAuthRequest();
                 rawResult = await request.ExecuteGetAsync(uri, _tokens);
@@ -212,7 +212,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         {
             try
             {
-                var uri = new Uri($"{BaseUrl}/search/tweets.json?q={Uri.EscapeDataString(hashTag)}&count={maxRecords}");
+                var uri = new Uri($"{BaseUrl}/search/tweets.json?q={Uri.EscapeDataString(hashTag)}&count={maxRecords}&tweet_mode=extended");
                 TwitterOAuthRequest request = new TwitterOAuthRequest();
                 var rawResult = await request.ExecuteGetAsync(uri, _tokens);
 
@@ -622,7 +622,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         {
             try
             {
-                var uri = new Uri($"{BaseUrl}/statuses/home_timeline.json?count={maxRecords}");
+                var uri = new Uri($"{BaseUrl}/statuses/home_timeline.json?count={maxRecords}&tweet_mode=extended");
 
                 TwitterOAuthRequest request = new TwitterOAuthRequest();
                 var rawResult = await request.ExecuteGetAsync(uri, _tokens);

--- a/docs/services/Twitter.md
+++ b/docs/services/Twitter.md
@@ -34,10 +34,11 @@ In the code section below the GetUserTimeLineAsync method returns some Tweet obj
 | Property | Type | Description |
 | -- | -- | -- |
 | **CreatedAt** | string | The date and time of the Tweet formatted by Twitter |
-| **Text** | string | The text of the Tweet |
+| **Text** | string | The text of the Tweet (if retweet, the text might not be complete - use the RetweetedStatus object for the original tweet)|
 | **Id** | string | The Twitter status identifier |
 | **GeoData** | TwitterGeoData | A class containing the latitude and longitude of the Tweet |
 | **User** | TwitterUser | A class containing the user ID, Name, ScreenName, and ProfileImageUrl |
+| **RetweetedStatus** | Tweet | if this tweet is a retweet, this object will contain the original tweet |
 
 ## Syntax
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Non streaming api calls do not include the full 280 characters of tweets

## What is the new behavior?
All api calls now include the full 280 characters

Reference twitter docs: https://developer.twitter.com/en/docs/tweets/tweet-updates

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Contains **NO** breaking changes



