### PR TITLE
Sample App Cache version checker

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/App.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/App.xaml.cs
@@ -128,6 +128,9 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                 Constants.ApplicationDisplayName = (await Package.Current.GetAppListEntriesAsync())[0].DisplayInfo.DisplayName;
             }
 
+            // Check if the Cache is Latest, wipe if not.
+            Sample.EnsureCacheLatest();
+
             Frame rootFrame = Window.Current.Content as Frame;
 
             // Do not repeat app initialization when the Window already has content,


### PR DESCRIPTION
Issue: #2045 
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
 - Sample app changes
 - Other... Please describe:
~Microsoft Docs Repo needs https://github.com/MicrosoftDocs/UWPCommunityToolkitDocs/pull/54 to go through for this to work.~

Checks SHA instead.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Sample app will show outdated docs if the docs are cached in an older release, and then a new version of the Toolkit gets released.

## What is the new behavior?

If the docsversion file in MicrosoftDocs/UWPCommunityToolkitDocs has a different Commit SHA than the Cached SHA, the Cache Folder gets wiped.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes