### PR TITLE
Flattening Markdown Namespaces.

### DIFF
--- a/Microsoft.Toolkit.Parsers/Markdown/Blocks/CodeBlock.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Blocks/CodeBlock.cs
@@ -11,7 +11,6 @@
 // ******************************************************************
 
 using System.Text;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Blocks

--- a/Microsoft.Toolkit.Parsers/Markdown/Blocks/HeaderBlock.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Blocks/HeaderBlock.cs
@@ -12,7 +12,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 using Microsoft.Toolkit.Parsers.Markdown.Inlines;
 

--- a/Microsoft.Toolkit.Parsers/Markdown/Blocks/HorizontalRuleBlock.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Blocks/HorizontalRuleBlock.cs
@@ -11,7 +11,6 @@
 // ******************************************************************
 
 using Microsoft.Toolkit.Parsers.Core;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Blocks
 {

--- a/Microsoft.Toolkit.Parsers/Markdown/Blocks/LinkReferenceBlock.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Blocks/LinkReferenceBlock.cs
@@ -11,7 +11,6 @@
 // ******************************************************************
 
 using Microsoft.Toolkit.Parsers.Core;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Inlines;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Blocks

--- a/Microsoft.Toolkit.Parsers/Markdown/Blocks/List/ListItemBlock.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Blocks/List/ListItemBlock.cs
@@ -12,7 +12,7 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.Toolkit.Parsers.Markdown.Blocks.List
+namespace Microsoft.Toolkit.Parsers.Markdown.Blocks
 {
     /// <summary>
     /// This specifies the Content of the List element.

--- a/Microsoft.Toolkit.Parsers/Markdown/Blocks/List/ListItemBuilder.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Blocks/List/ListItemBuilder.cs
@@ -11,9 +11,8 @@
 // ******************************************************************
 
 using System.Text;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 
-namespace Microsoft.Toolkit.Parsers.Markdown.Blocks.List
+namespace Microsoft.Toolkit.Parsers.Markdown.Blocks
 {
     internal class ListItemBuilder : MarkdownBlock
     {

--- a/Microsoft.Toolkit.Parsers/Markdown/Blocks/List/ListItemPreamble.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Blocks/List/ListItemPreamble.cs
@@ -10,9 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
-
-namespace Microsoft.Toolkit.Parsers.Markdown.Blocks.List
+namespace Microsoft.Toolkit.Parsers.Markdown.Blocks
 {
     internal class ListItemPreamble
     {

--- a/Microsoft.Toolkit.Parsers/Markdown/Blocks/List/NestedListInfo.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Blocks/List/NestedListInfo.cs
@@ -10,7 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-namespace Microsoft.Toolkit.Parsers.Markdown.Blocks.List
+namespace Microsoft.Toolkit.Parsers.Markdown.Blocks
 {
     internal class NestedListInfo
     {

--- a/Microsoft.Toolkit.Parsers/Markdown/Blocks/ListBlock.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Blocks/ListBlock.cs
@@ -17,8 +17,6 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Toolkit.Parsers.Core;
-using Microsoft.Toolkit.Parsers.Markdown.Blocks.List;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 [assembly: InternalsVisibleTo("UnitTests")]

--- a/Microsoft.Toolkit.Parsers/Markdown/Blocks/ParagraphBlock.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Blocks/ParagraphBlock.cs
@@ -11,7 +11,6 @@
 // ******************************************************************
 
 using System.Collections.Generic;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 using Microsoft.Toolkit.Parsers.Markdown.Inlines;
 

--- a/Microsoft.Toolkit.Parsers/Markdown/Blocks/QuoteBlock.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Blocks/QuoteBlock.cs
@@ -11,7 +11,6 @@
 // ******************************************************************
 
 using System.Collections.Generic;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Blocks
 {

--- a/Microsoft.Toolkit.Parsers/Markdown/Blocks/TableBlock.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Blocks/TableBlock.cs
@@ -13,7 +13,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Toolkit.Parsers.Core;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 using Microsoft.Toolkit.Parsers.Markdown.Inlines;
 

--- a/Microsoft.Toolkit.Parsers/Markdown/Enums/ColumnAlignment.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Enums/ColumnAlignment.cs
@@ -10,7 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-namespace Microsoft.Toolkit.Parsers.Markdown.Enums
+namespace Microsoft.Toolkit.Parsers.Markdown
 {
     /// <summary>
     /// The alignment of content in a table column.

--- a/Microsoft.Toolkit.Parsers/Markdown/Enums/HyperlinkType.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Enums/HyperlinkType.cs
@@ -10,7 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-namespace Microsoft.Toolkit.Parsers.Markdown.Enums
+namespace Microsoft.Toolkit.Parsers.Markdown
 {
     /// <summary>
     /// Specifies the type of Hyperlink that is used.

--- a/Microsoft.Toolkit.Parsers/Markdown/Enums/InlineParseMethod.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Enums/InlineParseMethod.cs
@@ -10,7 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-namespace Microsoft.Toolkit.Parsers.Markdown.Enums
+namespace Microsoft.Toolkit.Parsers.Markdown
 {
     internal enum InlineParseMethod
     {

--- a/Microsoft.Toolkit.Parsers/Markdown/Enums/ListStyle.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Enums/ListStyle.cs
@@ -10,7 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-namespace Microsoft.Toolkit.Parsers.Markdown.Enums
+namespace Microsoft.Toolkit.Parsers.Markdown
 {
     /// <summary>
     /// This specifies the type of style the List will be.

--- a/Microsoft.Toolkit.Parsers/Markdown/Enums/MarkdownBlockType.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Enums/MarkdownBlockType.cs
@@ -10,7 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-namespace Microsoft.Toolkit.Parsers.Markdown.Enums
+namespace Microsoft.Toolkit.Parsers.Markdown
 {
     /// <summary>
     /// Determines the type of Block the Block element is.

--- a/Microsoft.Toolkit.Parsers/Markdown/Enums/MarkdownInlineType.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Enums/MarkdownInlineType.cs
@@ -10,7 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-namespace Microsoft.Toolkit.Parsers.Markdown.Enums
+namespace Microsoft.Toolkit.Parsers.Markdown
 {
     /// <summary>
     /// Determines the type of Inline the Inline Element is.

--- a/Microsoft.Toolkit.Parsers/Markdown/Helpers/Common.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Helpers/Common.cs
@@ -13,7 +13,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Inlines;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Helpers

--- a/Microsoft.Toolkit.Parsers/Markdown/Helpers/InlineTripCharHelper.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Helpers/InlineTripCharHelper.cs
@@ -10,8 +10,6 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
-
 namespace Microsoft.Toolkit.Parsers.Markdown.Helpers
 {
     /// <summary>

--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/BoldItalicTextInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/BoldItalicTextInline.cs
@@ -12,7 +12,6 @@
 
 using System.Collections.Generic;
 using Microsoft.Toolkit.Parsers.Core;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines

--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/BoldTextInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/BoldTextInline.cs
@@ -12,7 +12,6 @@
 
 using System.Collections.Generic;
 using Microsoft.Toolkit.Parsers.Core;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines

--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/CodeInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/CodeInline.cs
@@ -11,7 +11,6 @@
 // ******************************************************************
 
 using System.Collections.Generic;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines

--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/CommentInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/CommentInline.cs
@@ -11,7 +11,6 @@
 // ******************************************************************
 
 using System.Collections.Generic;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines

--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/EmojiInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/EmojiInline.cs
@@ -12,7 +12,6 @@
 
 using System.Collections.Generic;
 using Microsoft.Toolkit.Parsers.Core;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines

--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/HyperlinkInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/HyperlinkInline.cs
@@ -13,7 +13,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines

--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/ImageInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/ImageInline.cs
@@ -13,7 +13,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Toolkit.Parsers.Core;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines

--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/ItalicTextInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/ItalicTextInline.cs
@@ -12,7 +12,6 @@
 
 using System.Collections.Generic;
 using Microsoft.Toolkit.Parsers.Core;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines

--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/LinkAnchorInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/LinkAnchorInline.cs
@@ -12,7 +12,6 @@
 
 using System.Collections.Generic;
 using System.Xml;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines

--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/MarkdownLinkInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/MarkdownLinkInline.cs
@@ -14,7 +14,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Toolkit.Extensions;
 using Microsoft.Toolkit.Parsers.Core;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines

--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/StrikethroughTextInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/StrikethroughTextInline.cs
@@ -12,7 +12,6 @@
 
 using System.Collections.Generic;
 using Microsoft.Toolkit.Parsers.Core;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines

--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/SuperscriptTextInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/SuperscriptTextInline.cs
@@ -11,7 +11,6 @@
 // ******************************************************************
 
 using System.Collections.Generic;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines

--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/TextRunInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/TextRunInline.cs
@@ -13,7 +13,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines
 {

--- a/Microsoft.Toolkit.Parsers/Markdown/MarkdownBlock.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/MarkdownBlock.cs
@@ -10,8 +10,6 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
-
 namespace Microsoft.Toolkit.Parsers.Markdown.Blocks
 {
     /// <summary>

--- a/Microsoft.Toolkit.Parsers/Markdown/MarkdownDocument.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/MarkdownDocument.cs
@@ -14,9 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.Toolkit.Extensions;
 using Microsoft.Toolkit.Parsers.Markdown.Blocks;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown

--- a/Microsoft.Toolkit.Parsers/Markdown/MarkdownInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/MarkdownInline.cs
@@ -10,8 +10,6 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
-
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines
 {
     /// <summary>

--- a/Microsoft.Toolkit.Parsers/Markdown/Render/MarkdownRendererBase.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Render/MarkdownRendererBase.cs
@@ -13,7 +13,6 @@
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Toolkit.Parsers.Markdown.Blocks;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Inlines;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Render

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Blocks.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Blocks.cs
@@ -12,8 +12,8 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Toolkit.Parsers.Markdown;
 using Microsoft.Toolkit.Parsers.Markdown.Blocks;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
 using Microsoft.Toolkit.Parsers.Markdown.Render;
 using Windows.UI.Text;
 using Windows.UI.Xaml;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Inlines.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Inlines.cs
@@ -13,7 +13,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Microsoft.Toolkit.Parsers.Markdown.Enums;
+using Microsoft.Toolkit.Parsers.Markdown;
 using Microsoft.Toolkit.Parsers.Markdown.Inlines;
 using Microsoft.Toolkit.Parsers.Markdown.Render;
 using Windows.UI.Text;
@@ -21,7 +21,6 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Documents;
 using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Media.Imaging;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
 {
@@ -280,6 +279,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
             {
                 ishyperlink = true;
             }
+
             LinkRegister.RegisterNewHyperLink(image, element.Url, ishyperlink);
 
             if (ImageMaxHeight > 0)


### PR DESCRIPTION
Issue: #1916
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Refactoring (no functional changes, no api changes)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Some unneeded `.Enums` and `.Blocks.List` namespaces.

## What is the new behavior?

Removed lasted Namespace section.

Namespace cleanup per #1916

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)

## Other information
This PR contains breaking changes. The namespaces for Markdown Parsers are now simpler.