### PR TITLE
Adding extra brush, default null, to outline control when gaze enters…

### DIFF
--- a/Microsoft.Toolkit.Uwp.Input.GazeInteraction/DwellProgressState.h
+++ b/Microsoft.Toolkit.Uwp.Input.GazeInteraction/DwellProgressState.h
@@ -13,6 +13,11 @@ public enum class DwellProgressState
     Idle,
 
     /// <summary>
+    /// Gaze has entered control but we're not yet showing progress.
+    /// </summary>
+    Fixating,
+
+    /// <summary>
     /// User is continuing to focus on a control with an intent to dwell and invoke
     /// </summary>
     Progressing,

--- a/Microsoft.Toolkit.Uwp.Input.GazeInteraction/GazeInput.cpp
+++ b/Microsoft.Toolkit.Uwp.Input.GazeInteraction/GazeInput.cpp
@@ -11,8 +11,19 @@
 using namespace Platform;
 using namespace Windows::UI;
 
-
 BEGIN_NAMESPACE_GAZE_INPUT
+
+static Brush^ s_enterBrush = nullptr;
+
+Brush^ GazeInput::DwellFeedbackEnterBrush::get()
+{
+    return s_enterBrush;
+}
+
+void GazeInput::DwellFeedbackEnterBrush::set(Brush^ value)
+{
+    s_enterBrush = value;
+}
 
 static Brush^ s_progressBrush = ref new SolidColorBrush(Colors::Green);
 

--- a/Microsoft.Toolkit.Uwp.Input.GazeInteraction/GazeInput.h
+++ b/Microsoft.Toolkit.Uwp.Input.GazeInteraction/GazeInput.h
@@ -72,6 +72,11 @@ public:
     static property DependencyProperty^ MaxDwellRepeatCountProperty { DependencyProperty^ get(); }
 
     /// <summary>
+    /// Gets or sets the brush to use when displaying the default indication that gaze entered a control
+    /// </summary>
+    static property Brush^ DwellFeedbackEnterBrush { Brush^ get(); void set(Brush^ value); }
+
+    /// <summary>
     /// Gets or sets the brush to use when displaying the default animation for dwell press
     /// </summary>
     static property Brush^ DwellFeedbackProgressBrush { Brush^ get(); void set(Brush^ value); }

--- a/Microsoft.Toolkit.Uwp.Input.GazeInteraction/GazeTargetItem.cpp
+++ b/Microsoft.Toolkit.Uwp.Input.GazeInteraction/GazeTargetItem.cpp
@@ -234,7 +234,8 @@ void GazeTargetItem::RaiseProgressEvent(DwellProgressState state)
             }
             else
             {
-                rectangle->Stroke = GazeInput::DwellFeedbackCompleteBrush;
+                rectangle->Stroke = state == DwellProgressState::Fixating ? 
+                    GazeInput::DwellFeedbackEnterBrush : GazeInput::DwellFeedbackCompleteBrush;
                 rectangle->Width = bounds.Width;
                 rectangle->Height = bounds.Height;
 

--- a/Microsoft.Toolkit.Uwp.Input.GazeInteraction/GazeTargetItem.h
+++ b/Microsoft.Toolkit.Uwp.Input.GazeInteraction/GazeTargetItem.h
@@ -61,6 +61,10 @@ internal:
         {
             switch (ElementState)
             {
+            case PointerState::Enter:
+                RaiseProgressEvent(DwellProgressState::Fixating);
+                break;
+
             case PointerState::Dwell:
             case PointerState::Fixation:
                 RaiseProgressEvent(DwellProgressState::Progressing);


### PR DESCRIPTION
… it, but prior to it becoming animated.

Placeholder text until/unless feature request text given.

Precis is adding a stationary outline around controls when gaze enters them, but before fixation starts being detected. This is intended to replace the cursor on densely packed user interfaces like keyboards where the cursor can be an unwanted distraction.

Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
