### PR TITLE
Update InheritDoc Cake task

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -19,6 +19,7 @@ var target = Argument("target", "Default");
 
 var gitVersioningVersion = "2.1.23";
 var signClientVersion = "0.9.0";
+var inheritDocVersion = "1.1.0.1";
 
 //////////////////////////////////////////////////////////////////////
 // VARIABLES
@@ -44,7 +45,6 @@ var versionClient = toolsDir + "/nerdbank.gitversioning/tools/Get-Version.ps1";
 string Version = null;
 
 var inheritDoc = toolsDir + "/InheritDoc/tools/InheritDoc.exe";
-var inheritDocKey = "PJKUD6-T4H34O-MUGPCM-LN5JKD-FWUWG2-32AECA";
 var inheritDocExclude = "Foo.*";
 
 var name = "Windows Community Toolkit";
@@ -184,12 +184,25 @@ Task("InheritDoc")
 	Information("\nDownloading InheritDoc...");
 	var installSettings = new NuGetInstallSettings {
 		ExcludeVersion = true,
+        Version = inheritDocVersion,
 		OutputDirectory = toolsDir
 	};
 
 	NuGetInstall(new []{"InheritDoc"}, installSettings);
+    
+    var args = new ProcessArgumentBuilder()
+                .AppendSwitchQuoted("-b", baseDir)
+                .AppendSwitch("-o", "")
+                .AppendSwitchQuoted("-x", inheritDocExclude);
 
-	StartProcess(inheritDoc, "-k " + inheritDocKey + " -b \"" + baseDir + "\" -o -x\"" + inheritDocExclude + "\"");
+    var result = StartProcess(inheritDoc, new ProcessSettings { Arguments = args });
+    
+    if (result != 0)
+    {
+        throw new InvalidOperationException("InheritDoc failed!");
+    }
+
+    Information("\nFinished generating documentation with InheritDoc");
 });
 
 Task("Package")


### PR DESCRIPTION
Issue: #2147
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
- Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
inheritdoc task used the latest version of the NuGet package. In the latest version, a breaking change was made to not require a license key which caused the task to fail, but build execution continued.

## What is the new behavior?
The implementation has been changed to indicate a specific package version to avoid unexpected breaking changes in the future. The process invocation has also been updated to ensure the documentation step completes successfully before continuing on to the next step during build.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
