### PR TITLE
Removed tabstop from ImageEx

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.xaml
@@ -5,6 +5,7 @@
     <Style TargetType="controls:ImageEx">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="{ThemeResource ApplicationForegroundThemeBrush}" />
+        <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:ImageEx">

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.xaml
@@ -7,6 +7,7 @@
         <Setter Property="Foreground" Value="{ThemeResource ApplicationForegroundThemeBrush}" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:RoundImageEx">


### PR DESCRIPTION
Issue: #2132 
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

 - Bugfix


## What is the new behavior?
ImageEx and RoundImageEx are not tab stops

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)

