### PR TITLE
Fixed tooltip text formatting on RangeSelector

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -623,13 +623,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private static void UpdateToolTipText(RangeSelector rangeSelector, TextBlock toolTip, double newValue)
         {
-            if (rangeSelector.StepFrequency < 1)
+            if (rangeSelector.StepFrequency % 1 == 0)
             {
-                toolTip.Text = string.Format("{0:0.00}", newValue);
+                toolTip.Text = string.Format("{0:0}", newValue);
             }
             else
             {
-                toolTip.Text = string.Format("{0:0}", newValue);
+                toolTip.Text = string.Format("{0:0.00}", newValue);
             }
         }
 
@@ -641,13 +641,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 return;
             }
 
-            if (rangeSelector.StepFrequency < 1)
+            if (rangeSelector.StepFrequency % 1 == 0)
             {
-                rangeSelector._minValueText.Text = string.Format("{0:0.00}", newValue);
+                rangeSelector._minValueText.Text = string.Format("{0:0}", newValue);
             }
             else
             {
-                rangeSelector._minValueText.Text = string.Format("{0:0}", newValue);
+                rangeSelector._minValueText.Text = string.Format("{0:0.00}", newValue);
             }
         }
 
@@ -659,13 +659,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 return;
             }
 
-            if (rangeSelector.StepFrequency < 1)
+            if (rangeSelector.StepFrequency % 1 == 0)
             {
-                rangeSelector._maxValueText.Text = string.Format("{0:0.00}", newValue);
+                rangeSelector._maxValueText.Text = string.Format("{0:0}", newValue);
             }
             else
             {
-                rangeSelector._maxValueText.Text = string.Format("{0:0}", newValue);
+                rangeSelector._maxValueText.Text = string.Format("{0:0.00}", newValue);
             }
         }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

 - Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
RangeSelector Tooltip doesn't show the decimal points when StepFrequency is a fraction

## What is the new behavior?
RangeSelector Tooltip shows the decimal points when StepFrequency is a fraction

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Contains **NO** breaking changes

