### PR TITLE
Platform Specific Analyser nupkg structure is correctly

### DIFF
--- a/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer.csproj
+++ b/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer.csproj
@@ -16,14 +16,16 @@
   </ItemGroup>
    
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.4.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.4.0" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.8.2" />
   </ItemGroup>
 
 </Project>

--- a/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer.csproj
+++ b/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer/Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/vb" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
VB specific analyser folder was not created and analyzer was not being copied to project when installing from nuget.

This PR fixes that issue.

Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<- Bugfix >
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When adding platform specific analyzer to VB project, the PSA is added a normal nuget package and not as an analyzer as vb specific folder was not found.

## What is the new behavior?
vb specific folder has been added and now the analyzer is loaded correctly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
