### PR TITLE
Enable setting EnterpriseId on WebView

### DIFF
--- a/Microsoft.Toolkit.Win32.UI.Controls/IWebView.cs
+++ b/Microsoft.Toolkit.Win32.UI.Controls/IWebView.cs
@@ -166,6 +166,14 @@ namespace Microsoft.Toolkit.Win32.UI.Controls
         string DocumentTitle { get; }
 
         /// <summary>
+        /// Gets or sets an enterprise ID for this process.
+        /// </summary>
+        /// <value>The enterprise ID of this process.</value>
+        /// <remarks>Value can be set prior to the component being initialized.</remarks>
+        /// <see cref="WebViewControlProcessOptions.EnterpriseId"/>
+        string EnterpriseId { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the use of IndexedDB is allowed.
         /// </summary>
         /// <value><c>true</c> if IndexedDB is allowed; otherwise, <c>false</c>. The default is <c>true</c>.</value>
@@ -186,7 +194,6 @@ namespace Microsoft.Toolkit.Win32.UI.Controls
         /// <remarks>Value can be set prior to the component being initialized.</remarks>
         /// <see cref="WebViewControlProcessOptions.PrivateNetworkClientServerCapability"/>
         bool IsPrivateNetworkClientServerCapabilityEnabled { get; set; }
-
         /// <summary>
         /// Gets or sets a value indicating whether <see cref="IWebView.ScriptNotify" /> is allowed.
         /// </summary>

--- a/Microsoft.Toolkit.Win32.UI.Controls/Interop/WinRT/WebViewDefaults.cs
+++ b/Microsoft.Toolkit.Win32.UI.Controls/Interop/WinRT/WebViewDefaults.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
     internal static class WebViewDefaults
     {
         public const string AboutBlank = "about:blank";
+        public const string EnterpriseId = "";
         public const bool IsIndexedDBEnabled = true;
         public const bool IsJavaScriptEnabled = true;
         public const bool IsPrivateNetworkEnabled = false;

--- a/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.Init.cs
+++ b/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.Init.cs
@@ -131,7 +131,8 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
                     {
                         PrivateNetworkClientServerCapability = _delayedPrivateNetworkEnabled
                                                                     ? WebViewControlProcessCapabilityState.Enabled
-                                                                    : WebViewControlProcessCapabilityState.Disabled
+                                                                    : WebViewControlProcessCapabilityState.Disabled,
+                        EnterpriseId = _delayedEnterpriseId
                     });
                     _webViewControl = Process.CreateWebViewControlHost(Handle, ClientRectangle);
                     SubscribeEvents();

--- a/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.cs
+++ b/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
     [PermissionSet(SecurityAction.InheritanceDemand, Name = Constants.SecurityPermissionSetName)]
     public sealed partial class WebView : Control, IWebView, ISupportInitialize
     {
+        private string _delayedEnterpriseId = WebViewDefaults.EnterpriseId;
         private bool _delayedIsIndexDbEnabled = WebViewDefaults.IsIndexedDBEnabled;
         private bool _delayedIsJavaScriptEnabled = WebViewDefaults.IsJavaScriptEnabled;
         private bool _delayedIsScriptNotifyAllowed = WebViewDefaults.IsScriptNotifyEnabled;
@@ -103,6 +104,37 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
                 Verify.IsFalse(IsDisposed);
                 Verify.IsNotNull(_webViewControl);
                 return _webViewControl?.DocumentTitle;
+            }
+        }
+
+        /// <inheritdoc />
+        [StringResourceCategory(Constants.CategoryBehavior)]
+        [DefaultValue(WebViewDefaults.EnterpriseId)]
+        public string EnterpriseId
+        {
+            get
+            {
+                Verify.IsFalse(IsDisposed);
+                Verify.Implies(Initializing, !Initialized);
+                Verify.Implies(Initialized, WebViewControlInitialized);
+                return WebViewControlInitialized
+                    ? _webViewControl.Process.EnterpriseId
+                    : _delayedEnterpriseId;
+            }
+
+            set
+            {
+                Verify.IsFalse(IsDisposed);
+                _delayedEnterpriseId = value;
+                if (!DesignMode)
+                {
+                    EnsureInitialized();
+                    if (WebViewControlInitialized
+                        && !string.Equals(_delayedEnterpriseId, _webViewControl.Process.EnterpriseId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException(DesignerUI.E_CANNOT_CHANGE_AFTER_INIT);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
EnterpriseId is now a property that can be set from a designer or during initialization prior to completing control initialization with the ISupportInitialize interface.

Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently there is no way to set the Enterprise partition ID on a WebView instance since the methods for creating the WebViews are internal. 

## What is the new behavior?
Using the `EnterpriseId` property, the value for the underlying process can be set until more advanced initialization scenarios are permitted.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
