### PR TITLE
Add script for installing Windows SDK from ISO

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -18,6 +18,9 @@ steps:
   inputs:
     versionSpec: 4.6.2
 
+- powershell: .\build\Install-WindowsSdkISO.ps1 17704
+  displayName: Insider SDK
+
 - task: DotNetCoreCLI@2
   inputs:
     command: build

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -15,7 +15,7 @@ steps:
   inputs:
     versionSpec: 4.6.2
 
-- powershell: .\build\Install-WindowsSdkISO.ps1
+- powershell: .\build\Install-WindowsSdkISO.ps1 17704
   displayName: Insider SDK
 
 - powershell: .\build\build.ps1 -target=Package

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -15,6 +15,9 @@ steps:
   inputs:
     versionSpec: 4.6.2
 
+- powershell: .\build\Install-WindowsSdkISO.ps1
+  displayName: Insider SDK
+
 - powershell: .\build\build.ps1 -target=Package
   displayName: Build 
 

--- a/build/Install-WindowsSdkISO.ps1
+++ b/build/Install-WindowsSdkISO.ps1
@@ -1,5 +1,5 @@
 # Set the URI for the SDK
-$uri = "https://go.microsoft.com/fwlink/p/?linkid=870809"
+$uri = "https://software-download.microsoft.com/pr/Windows_InsiderPreview_SDK_en-us_17682.iso?t=6d2e1eab-5165-41f8-91db-0b984e6e3607&e=1528546451&h=e1883e07e28ccc29c2495c94bae6fef7"
 
 if ($env:TEMP -eq $null) {
   $env:TEMP = Join-Path $env:SystemDrive 'temp'

--- a/build/Install-WindowsSdkISO.ps1
+++ b/build/Install-WindowsSdkISO.ps1
@@ -1,5 +1,7 @@
 # Set the URI for the SDK
-$uri = "https://software-download.microsoft.com/pr/Windows_InsiderPreview_SDK_en-us_17682.iso?t=6d2e1eab-5165-41f8-91db-0b984e6e3607&e=1528546451&h=e1883e07e28ccc29c2495c94bae6fef7"
+param([string]$buildNumber)
+
+$uri = "https://go.microsoft.com/fwlink/?prd=11966&pver=1.0&plcid=0x409&clcid=0x409&ar=Flight&sar=Sdsurl&o1=$buildNumber"
 
 if ($env:TEMP -eq $null) {
   $env:TEMP = Join-Path $env:SystemDrive 'temp'

--- a/build/Install-WindowsSdkISO.ps1
+++ b/build/Install-WindowsSdkISO.ps1
@@ -1,0 +1,119 @@
+# Set the URI for the SDK
+$uri = "https://go.microsoft.com/fwlink/p/?linkid=870809"
+
+if ($env:TEMP -eq $null) {
+  $env:TEMP = Join-Path $env:SystemDrive 'temp'
+}
+
+$winsdkTempDir = Join-Path $env:TEMP "WindowsSDK"
+
+if (![System.IO.Directory]::Exists($winsdkTempDir)) {
+  [void][System.IO.Directory]::CreateDirectory($winsdkTempDir)
+}
+
+$file = "winsdk.iso"
+
+function Download-File {
+param (
+  [string] $outDir,
+  [string] $downloadUrl,
+  [string] $downloadName
+)
+  # The ISO file can be large (800 MB), we want to use smart caching if we can to avoid long delays
+  # Note that some sources explicitly disable caching, so this may not be possible
+  $etagFile = Join-path $outDir "$downloadName.ETag"
+  $downloadPath = Join-Path $outDir "$downloadName.download"
+  $downloadDest = Join-Path $outDir $downloadName
+  $downloadDestTemp = Join-Path $outDir "$downloadName.tmp"
+  $headers = @{}
+
+  Write-Host -NoNewline "Ensuring that $downloadName is up to date..."
+
+  # if the destination folder doesn't exist, delete the ETAG file if it exists
+  if (!(Test-Path -PathType Container $downloadDest) -and (Test-Path -PathType Container $etagFile)) {
+    Remove-Item -Force $etagFile
+  }
+
+  if (Test-Path $etagFile) {
+    $headers.Add("If-None-Match", [System.IO.File]::ReadAllText($etagFile))
+  }
+
+  try {
+    # Dramatically speeds up download performance
+    $ProgressPreference = 'SilentlyContinue'
+    $response = Invoke-WebRequest -Headers $headers -Uri $downloadUrl -PassThru -OutFile $downloadPath -UseBasicParsing
+  } catch [System.Net.WebException] {
+    $response = $_.Exception.Response
+  }
+
+  if ($response.StatusCode -eq 200) {
+    Unblock-File $downloadPath
+    [System.IO.File]::WriteAllText($etagFile, $response.Headers["ETag"])
+
+    $downloadDestTemp = $downloadPath;
+    
+
+    # Delete and rename to final dest
+    if (Test-Path -PathType Container $downloadDest) {
+        [System.IO.Directory]::Delete($downloadDest, $true)
+    }
+
+    Move-Item -Force $downloadDestTemp $downloadDest
+    Write-Host "Updated $downloadName"
+  } elseif ($response.StatusCode -eq 304) {
+    Write-Host "Done"
+  } else {
+	Write-Host
+    Write-Warning "Failed to fetch updated file from $downloadUrl"
+    if (!(Test-Path $downloadDest)) {
+        throw "$downloadName was not found at $downloadDest"
+    } else {
+        Write-Warning "$downloadName may be out of date"
+    }
+  }
+
+  return $downloadDest  
+}
+
+function Mount-ISO {
+param (
+  [string] $isoPath
+)
+  # Check if image is already mounted
+  $isoDrive = (Get-DiskImage -ImagePath $isoPath | Get-Volume).DriveLetter
+
+  if (!$isoDrive) {
+    Mount-DiskImage -ImagePath $isoPath -StorageType ISO
+  }
+
+  $isoVolume = (Get-DiskImage -ImagePath $isoPath | Get-Volume)
+  $isoDrive = $isoVolume.DriveLetter + ":"
+
+  Write-Host "$isoPath mounted to $isoDrive"
+
+  return $isoDrive
+}
+
+function Dismount-ISO {
+param (
+  [string] $isoPath
+)
+  $isoDrive = (Get-DiskImage -ImagePath $isoPath | Get-Volume).DriveLetter 
+  if ($isoDrive) {
+    Dismount-DiskImage -ImagePath $isoPath
+  }
+}
+
+Write-Output "Getting WinSDK from $uri"
+$downloadFile = Download-File $winsdkTempDir $uri $file
+
+# TODO Check if zip, exe, iso, etc.
+Write-Output "Mounting ISO $file..."
+$isoDrive = Mount-ISO $downloadFile
+
+
+Write-Host "Installing WinSDK"
+$setupPath = Join-Path $isoDrive "WinSDKSetup.exe"
+Start-Process -Wait $setupPath "/features OptionId.UWPCpp /q"
+
+Dismount-ISO $downloadFile


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
- Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Can't download or use ISO image to install Windows SDK

## What is the new behavior?
Script will download the ISO image from a URI, write out the cache information and use HTTP features for cache. If the file is out of date, a new file is downloaded in its place. If the file does not exist, is out of date, or it cannot be determined from the HTTP header, a new file is downloaded.  After the file is downloaded the ISO image is mounted, and the installation proceeds. Once finished the ISO is dismounted.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
