### PR TITLE
Fix name parameter for the SchemeListProperty in MarkdownTextBlock

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Properties.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Gets the dependency property for <see cref="UriPrefix"/>.
         /// </summary>
         public static readonly DependencyProperty SchemeListProperty = DependencyProperty.Register(
-            nameof(UriPrefix),
+            nameof(SchemeList),
             typeof(string),
             typeof(MarkdownTextBlock),
             new PropertyMetadata(string.Empty, OnPropertyChangedStatic));


### PR DESCRIPTION
## PR Type

Bugfix

## PR Checklist

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Contains **NO** breaking changes

## Other information

I just fixed a tiny bug: In the MarkdownTextBlock, the `SchemeList` dependency property (`SchemeListProperty`) had it's `name` parameter incorrectly set to `nameof(UriPrefix)` (from copy-pasting the previous property, I assume). I simply changed it to the correct `nameof(SchemeList)`
