### PR TITLE
[Partial Fix]MarkdownTextBlock Memory leak: Subscribe/Unsubscribe event handler 

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -76,12 +76,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             ForegroundPropertyToken = RegisterPropertyChangedCallback(ForegroundProperty, OnPropertyChanged);
             PaddingPropertyToken = RegisterPropertyChangedCallback(PaddingProperty, OnPropertyChanged);
             RequestedThemePropertyToken = RegisterPropertyChangedCallback(RequestedThemeProperty, OnPropertyChanged);
+
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
         {
             UnhookListeners();
             themeListener.ThemeChanged -= ThemeListener_ThemeChanged;
+            themeListener.Dispose();
             themeListener = null;
 
             // Register for property callbacks that are owned by our parent class.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -46,8 +46,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             // Set our style.
             DefaultStyleKey = typeof(MarkdownTextBlock);
 
-            // Set our style.
-            DefaultStyleKey = typeof(MarkdownTextBlock);
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
         }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             // Set our style.
             DefaultStyleKey = typeof(MarkdownTextBlock);
-            themeListener = new Helpers.ThemeListener();
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
         }
@@ -60,8 +59,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
-            // Listens for theme changes and updates the rendering.
-            themeListener.ThemeChanged += ThemeListener_ThemeChanged;
+            // ThemeListener Initializer: Returns a boolean which indicates if the themeListener was previously null.
+            InitializeThemeListener();
 
             // Register for property callbacks that are owned by our parent class.
             FontSizePropertyToken = RegisterPropertyChangedCallback(FontSizeProperty, OnPropertyChanged);
@@ -76,7 +75,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             ForegroundPropertyToken = RegisterPropertyChangedCallback(ForegroundProperty, OnPropertyChanged);
             PaddingPropertyToken = RegisterPropertyChangedCallback(PaddingProperty, OnPropertyChanged);
             RequestedThemePropertyToken = RegisterPropertyChangedCallback(RequestedThemeProperty, OnPropertyChanged);
-
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -103,11 +101,27 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <inheritdoc />
         protected override void OnApplyTemplate()
         {
+            // ThemeListener Initializer: Returns a boolean which indicates if the themeListener was previously null.
+            InitializeThemeListener();
+
             // Grab our root
             _rootElement = GetTemplateChild("RootElement") as Border;
 
             // And make sure to render any markdown we have.
             RenderMarkdown();
+        }
+
+        private bool InitializeThemeListener()
+        {
+            bool wasNull = false;
+            if (themeListener == null)
+            {
+                wasNull = true;
+                themeListener = new Helpers.ThemeListener();
+                themeListener.ThemeChanged += ThemeListener_ThemeChanged;
+            }
+
+            return wasNull;
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -13,30 +13,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// </summary>
     public sealed partial class MarkdownTextBlock : Control, ILinkRegister, IImageResolver, ICodeBlockResolver
     {
-
-        private long _fontSizePropertyToken { get; set; }
-
-        private long _backgroundPropertyToken { get; set; }
-
-        private long _borderBrushPropertyToken { get; set; }
-
-        private long _borderThicknessPropertyToken { get; set; }
-
-        private long _characterSpacingPropertyToken { get; set; }
-
-        private long _fontFamilyPropertyToken { get; set; }
-
-        private long _fontStretchPropertyToken { get; set; }
-
-        private long _fontStylePropertyToken { get; set; }
-
-        private long _fontWeightPropertyToken { get; set; }
-
-        private long _foregroundPropertyToken { get; set; }
-
-        private long _paddingPropertyToken { get; set; }
-
-        private long _requestedThemePropertyToken { get; set; }
+        private long _fontSizePropertyToken;
+        private long _backgroundPropertyToken;
+        private long _borderBrushPropertyToken;
+        private long _borderThicknessPropertyToken;
+        private long _characterSpacingPropertyToken;
+        private long _fontFamilyPropertyToken;
+        private long _fontStretchPropertyToken;
+        private long _fontStylePropertyToken;
+        private long _fontWeightPropertyToken;
+        private long _foregroundPropertyToken;
+        private long _paddingPropertyToken;
+        private long _requestedThemePropertyToken;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MarkdownTextBlock"/> class.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             ForegroundPropertyToken = RegisterPropertyChangedCallback(ForegroundProperty, OnPropertyChanged);
             PaddingPropertyToken = RegisterPropertyChangedCallback(PaddingProperty, OnPropertyChanged);
             RequestedThemePropertyToken = RegisterPropertyChangedCallback(RequestedThemeProperty, OnPropertyChanged);
-
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -97,9 +96,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             UnregisterPropertyChangedCallback(ForegroundProperty, ForegroundPropertyToken);
             UnregisterPropertyChangedCallback(PaddingProperty, PaddingPropertyToken);
             UnregisterPropertyChangedCallback(RequestedThemeProperty, RequestedThemePropertyToken);
-            _rootElement = null;
         }
-
 
         /// <inheritdoc />
         protected override void OnApplyTemplate()

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -59,7 +59,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
-            // ThemeListener Initializer: Returns a boolean which indicates if the themeListener was previously null.
             RegisterThemeChangedHandler();
 
             // Register for property callbacks that are owned by our parent class.
@@ -79,10 +78,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
         {
-            UnhookListeners();
-            themeListener.ThemeChanged -= ThemeListener_ThemeChanged;
-            themeListener.Dispose();
-            themeListener = null;
+            if (themeListener != null)
+            {
+                UnhookListeners();
+                themeListener.ThemeChanged -= ThemeListener_ThemeChanged;
+                themeListener.Dispose();
+                themeListener = null;
+            }
 
             // Register for property callbacks that are owned by our parent class.
             UnregisterPropertyChangedCallback(FontSizeProperty, FontSizePropertyToken);
@@ -101,7 +103,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <inheritdoc />
         protected override void OnApplyTemplate()
         {
-            // ThemeListener Initializer: Returns a boolean which indicates if the themeListener was previously null.
             RegisterThemeChangedHandler();
 
             // Grab our root
@@ -114,6 +115,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private void RegisterThemeChangedHandler()
         {
             themeListener = themeListener ?? new Helpers.ThemeListener();
+            themeListener.ThemeChanged -= ThemeListener_ThemeChanged;
             themeListener.ThemeChanged += ThemeListener_ThemeChanged;
         }
     }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -1,14 +1,6 @@
-// ******************************************************************
-// Copyright (c) Microsoft. All rights reserved.
-// This code is licensed under the MIT License (MIT).
-// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
-// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
-// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
-// ******************************************************************
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render;
 using Windows.UI.Xaml;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -14,29 +14,29 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public sealed partial class MarkdownTextBlock : Control, ILinkRegister, IImageResolver, ICodeBlockResolver
     {
 
-        private long FontSizePropertyToken { get; set; }
+        private long _fontSizePropertyToken { get; set; }
 
-        private long BackgroundPropertyToken { get; set; }
+        private long _backgroundPropertyToken { get; set; }
 
-        private long BorderBrushPropertyToken { get; set; }
+        private long _borderBrushPropertyToken { get; set; }
 
-        private long BorderThicknessPropertyToken { get; set; }
+        private long _borderThicknessPropertyToken { get; set; }
 
-        private long CharacterSpacingPropertyToken { get; set; }
+        private long _characterSpacingPropertyToken { get; set; }
 
-        private long FontFamilyPropertyToken { get; set; }
+        private long _fontFamilyPropertyToken { get; set; }
 
-        private long FontStretchPropertyToken { get; set; }
+        private long _fontStretchPropertyToken { get; set; }
 
-        private long FontStylePropertyToken { get; set; }
+        private long _fontStylePropertyToken { get; set; }
 
-        private long FontWeightPropertyToken { get; set; }
+        private long _fontWeightPropertyToken { get; set; }
 
-        private long ForegroundPropertyToken { get; set; }
+        private long _foregroundPropertyToken { get; set; }
 
-        private long PaddingPropertyToken { get; set; }
+        private long _paddingPropertyToken { get; set; }
 
-        private long RequestedThemePropertyToken { get; set; }
+        private long _requestedThemePropertyToken { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MarkdownTextBlock"/> class.
@@ -62,18 +62,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             RegisterThemeChangedHandler();
 
             // Register for property callbacks that are owned by our parent class.
-            FontSizePropertyToken = RegisterPropertyChangedCallback(FontSizeProperty, OnPropertyChanged);
-            BackgroundPropertyToken = RegisterPropertyChangedCallback(BackgroundProperty, OnPropertyChanged);
-            BorderBrushPropertyToken = RegisterPropertyChangedCallback(BorderBrushProperty, OnPropertyChanged);
-            BorderThicknessPropertyToken = RegisterPropertyChangedCallback(BorderThicknessProperty, OnPropertyChanged);
-            CharacterSpacingPropertyToken = RegisterPropertyChangedCallback(CharacterSpacingProperty, OnPropertyChanged);
-            FontFamilyPropertyToken = RegisterPropertyChangedCallback(FontFamilyProperty, OnPropertyChanged);
-            FontStretchPropertyToken = RegisterPropertyChangedCallback(FontStretchProperty, OnPropertyChanged);
-            FontStylePropertyToken = RegisterPropertyChangedCallback(FontStyleProperty, OnPropertyChanged);
-            FontWeightPropertyToken = RegisterPropertyChangedCallback(FontWeightProperty, OnPropertyChanged);
-            ForegroundPropertyToken = RegisterPropertyChangedCallback(ForegroundProperty, OnPropertyChanged);
-            PaddingPropertyToken = RegisterPropertyChangedCallback(PaddingProperty, OnPropertyChanged);
-            RequestedThemePropertyToken = RegisterPropertyChangedCallback(RequestedThemeProperty, OnPropertyChanged);
+            _fontSizePropertyToken = RegisterPropertyChangedCallback(FontSizeProperty, OnPropertyChanged);
+            _backgroundPropertyToken = RegisterPropertyChangedCallback(BackgroundProperty, OnPropertyChanged);
+            _borderBrushPropertyToken = RegisterPropertyChangedCallback(BorderBrushProperty, OnPropertyChanged);
+            _borderThicknessPropertyToken = RegisterPropertyChangedCallback(BorderThicknessProperty, OnPropertyChanged);
+            _characterSpacingPropertyToken = RegisterPropertyChangedCallback(CharacterSpacingProperty, OnPropertyChanged);
+            _fontFamilyPropertyToken = RegisterPropertyChangedCallback(FontFamilyProperty, OnPropertyChanged);
+            _fontStretchPropertyToken = RegisterPropertyChangedCallback(FontStretchProperty, OnPropertyChanged);
+            _fontStylePropertyToken = RegisterPropertyChangedCallback(FontStyleProperty, OnPropertyChanged);
+            _fontWeightPropertyToken = RegisterPropertyChangedCallback(FontWeightProperty, OnPropertyChanged);
+            _foregroundPropertyToken = RegisterPropertyChangedCallback(ForegroundProperty, OnPropertyChanged);
+            _paddingPropertyToken = RegisterPropertyChangedCallback(PaddingProperty, OnPropertyChanged);
+            _requestedThemePropertyToken = RegisterPropertyChangedCallback(RequestedThemeProperty, OnPropertyChanged);
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -87,17 +87,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
 
             // Register for property callbacks that are owned by our parent class.
-            UnregisterPropertyChangedCallback(FontSizeProperty, FontSizePropertyToken);
-            UnregisterPropertyChangedCallback(BackgroundProperty, BackgroundPropertyToken);
-            UnregisterPropertyChangedCallback(BorderBrushProperty, BorderBrushPropertyToken);
-            UnregisterPropertyChangedCallback(BorderThicknessProperty, BorderThicknessPropertyToken);
-            UnregisterPropertyChangedCallback(CharacterSpacingProperty, CharacterSpacingPropertyToken);
-            UnregisterPropertyChangedCallback(FontFamilyProperty, FontFamilyPropertyToken);
-            UnregisterPropertyChangedCallback(FontStretchProperty, FontStylePropertyToken);
-            UnregisterPropertyChangedCallback(FontWeightProperty, FontWeightPropertyToken);
-            UnregisterPropertyChangedCallback(ForegroundProperty, ForegroundPropertyToken);
-            UnregisterPropertyChangedCallback(PaddingProperty, PaddingPropertyToken);
-            UnregisterPropertyChangedCallback(RequestedThemeProperty, RequestedThemePropertyToken);
+            UnregisterPropertyChangedCallback(FontSizeProperty, _fontSizePropertyToken);
+            UnregisterPropertyChangedCallback(BackgroundProperty, _backgroundPropertyToken);
+            UnregisterPropertyChangedCallback(BorderBrushProperty, _borderBrushPropertyToken);
+            UnregisterPropertyChangedCallback(BorderThicknessProperty, _borderThicknessPropertyToken);
+            UnregisterPropertyChangedCallback(CharacterSpacingProperty, _characterSpacingPropertyToken);
+            UnregisterPropertyChangedCallback(FontFamilyProperty, _fontFamilyPropertyToken);
+            UnregisterPropertyChangedCallback(FontStretchProperty, _fontStylePropertyToken);
+            UnregisterPropertyChangedCallback(FontWeightProperty, _fontWeightPropertyToken);
+            UnregisterPropertyChangedCallback(ForegroundProperty, _foregroundPropertyToken);
+            UnregisterPropertyChangedCallback(PaddingProperty, _paddingPropertyToken);
+            UnregisterPropertyChangedCallback(RequestedThemeProperty, _requestedThemePropertyToken);
         }
 
         /// <inheritdoc />

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -1,6 +1,14 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
 
 using Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render;
 using Windows.UI.Xaml;
@@ -13,6 +21,31 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// </summary>
     public sealed partial class MarkdownTextBlock : Control, ILinkRegister, IImageResolver, ICodeBlockResolver
     {
+
+        private long FontSizePropertyToken { get; set; }
+
+        private long BackgroundPropertyToken { get; set; }
+
+        private long BorderBrushPropertyToken { get; set; }
+
+        private long BorderThicknessPropertyToken { get; set; }
+
+        private long CharacterSpacingPropertyToken { get; set; }
+
+        private long FontFamilyPropertyToken { get; set; }
+
+        private long FontStretchPropertyToken { get; set; }
+
+        private long FontStylePropertyToken { get; set; }
+
+        private long FontWeightPropertyToken { get; set; }
+
+        private long ForegroundPropertyToken { get; set; }
+
+        private long PaddingPropertyToken { get; set; }
+
+        private long RequestedThemePropertyToken { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MarkdownTextBlock"/> class.
         /// </summary>
@@ -21,31 +54,60 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             // Set our style.
             DefaultStyleKey = typeof(MarkdownTextBlock);
 
-            // Listens for theme changes and updates the rendering.
+            // Set our style.
+            DefaultStyleKey = typeof(MarkdownTextBlock);
             themeListener = new Helpers.ThemeListener();
-            themeListener.ThemeChanged += ThemeListener_ThemeChanged;
-
-            // Register for property callbacks that are owned by our parent class.
-            RegisterPropertyChangedCallback(FontSizeProperty, OnPropertyChanged);
-            RegisterPropertyChangedCallback(BackgroundProperty, OnPropertyChanged);
-            RegisterPropertyChangedCallback(BorderBrushProperty, OnPropertyChanged);
-            RegisterPropertyChangedCallback(BorderThicknessProperty, OnPropertyChanged);
-            RegisterPropertyChangedCallback(CharacterSpacingProperty, OnPropertyChanged);
-            RegisterPropertyChangedCallback(FontFamilyProperty, OnPropertyChanged);
-            RegisterPropertyChangedCallback(FontSizeProperty, OnPropertyChanged);
-            RegisterPropertyChangedCallback(FontStretchProperty, OnPropertyChanged);
-            RegisterPropertyChangedCallback(FontStyleProperty, OnPropertyChanged);
-            RegisterPropertyChangedCallback(FontWeightProperty, OnPropertyChanged);
-            RegisterPropertyChangedCallback(ForegroundProperty, OnPropertyChanged);
-            RegisterPropertyChangedCallback(PaddingProperty, OnPropertyChanged);
-            RegisterPropertyChangedCallback(RequestedThemeProperty, OnPropertyChanged);
-            RegisterPropertyChangedCallback(SchemeListProperty, OnPropertyChanged);
+            Loaded += OnLoaded;
+            Unloaded += OnUnloaded;
         }
 
         private void ThemeListener_ThemeChanged(Helpers.ThemeListener sender)
         {
             RenderMarkdown();
         }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            // Listens for theme changes and updates the rendering.
+            themeListener.ThemeChanged += ThemeListener_ThemeChanged;
+
+            // Register for property callbacks that are owned by our parent class.
+            FontSizePropertyToken = RegisterPropertyChangedCallback(FontSizeProperty, OnPropertyChanged);
+            BackgroundPropertyToken = RegisterPropertyChangedCallback(BackgroundProperty, OnPropertyChanged);
+            BorderBrushPropertyToken = RegisterPropertyChangedCallback(BorderBrushProperty, OnPropertyChanged);
+            BorderThicknessPropertyToken = RegisterPropertyChangedCallback(BorderThicknessProperty, OnPropertyChanged);
+            CharacterSpacingPropertyToken = RegisterPropertyChangedCallback(CharacterSpacingProperty, OnPropertyChanged);
+            FontFamilyPropertyToken = RegisterPropertyChangedCallback(FontFamilyProperty, OnPropertyChanged);
+            FontStretchPropertyToken = RegisterPropertyChangedCallback(FontStretchProperty, OnPropertyChanged);
+            FontStylePropertyToken = RegisterPropertyChangedCallback(FontStyleProperty, OnPropertyChanged);
+            FontWeightPropertyToken = RegisterPropertyChangedCallback(FontWeightProperty, OnPropertyChanged);
+            ForegroundPropertyToken = RegisterPropertyChangedCallback(ForegroundProperty, OnPropertyChanged);
+            PaddingPropertyToken = RegisterPropertyChangedCallback(PaddingProperty, OnPropertyChanged);
+            RequestedThemePropertyToken = RegisterPropertyChangedCallback(RequestedThemeProperty, OnPropertyChanged);
+
+        }
+
+        private void OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            UnhookListeners();
+            themeListener.ThemeChanged -= ThemeListener_ThemeChanged;
+            themeListener = null;
+
+            // Register for property callbacks that are owned by our parent class.
+            UnregisterPropertyChangedCallback(FontSizeProperty, FontSizePropertyToken);
+            UnregisterPropertyChangedCallback(BackgroundProperty, BackgroundPropertyToken);
+            UnregisterPropertyChangedCallback(BorderBrushProperty, BorderBrushPropertyToken);
+            UnregisterPropertyChangedCallback(BorderThicknessProperty, BorderThicknessPropertyToken);
+            UnregisterPropertyChangedCallback(CharacterSpacingProperty, CharacterSpacingPropertyToken);
+            UnregisterPropertyChangedCallback(FontFamilyProperty, FontFamilyPropertyToken);
+            UnregisterPropertyChangedCallback(FontStretchProperty, FontStylePropertyToken);
+            UnregisterPropertyChangedCallback(FontWeightProperty, FontWeightPropertyToken);
+            UnregisterPropertyChangedCallback(ForegroundProperty, ForegroundPropertyToken);
+            UnregisterPropertyChangedCallback(PaddingProperty, PaddingPropertyToken);
+            UnregisterPropertyChangedCallback(RequestedThemeProperty, RequestedThemePropertyToken);
+            _rootElement = null;
+        }
+
 
         /// <inheritdoc />
         protected override void OnApplyTemplate()

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
             // ThemeListener Initializer: Returns a boolean which indicates if the themeListener was previously null.
-            InitializeThemeListener();
+            RegisterThemeChangedHandler();
 
             // Register for property callbacks that are owned by our parent class.
             FontSizePropertyToken = RegisterPropertyChangedCallback(FontSizeProperty, OnPropertyChanged);
@@ -102,7 +102,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         protected override void OnApplyTemplate()
         {
             // ThemeListener Initializer: Returns a boolean which indicates if the themeListener was previously null.
-            InitializeThemeListener();
+            RegisterThemeChangedHandler();
 
             // Grab our root
             _rootElement = GetTemplateChild("RootElement") as Border;
@@ -111,17 +111,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             RenderMarkdown();
         }
 
-        private bool InitializeThemeListener()
+        private void RegisterThemeChangedHandler()
         {
-            bool wasNull = false;
-            if (themeListener == null)
-            {
-                wasNull = true;
-                themeListener = new Helpers.ThemeListener();
-                themeListener.ThemeChanged += ThemeListener_ThemeChanged;
-            }
-
-            return wasNull;
+            themeListener = themeListener ?? new Helpers.ThemeListener();
+            themeListener.ThemeChanged += ThemeListener_ThemeChanged;
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/Helpers/ThemeListener.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Helpers/ThemeListener.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Helpers
     /// and Signals an Event when they occur.
     /// </summary>
     [AllowForWeb]
-    public sealed class ThemeListener
+    public sealed class ThemeListener : IDisposable
     {
         /// <summary>
         /// Gets the Name of the Current Theme.
@@ -126,6 +126,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Helpers
             }
 
             ThemeChanged?.Invoke(this);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _accessible.HighContrastChanged -= Accessible_HighContrastChanged;
+            _settings.ColorValuesChanged -= Settings_ColorValuesChanged;
+            Window.Current.CoreWindow.Activated -= CoreWindow_Activated;
         }
     }
 }


### PR DESCRIPTION
Issue: #2258 
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
When the MarkDownTextBlock it's initialized, it subscribes to many events, but after rendering it doesn't unsubscribe from them. This causes a memory leaking problem because the object is still linked to unnecessary actions. 
## What is the new behavior?
To avoid this, I've implemented the Loading and Unloading method in order to handle properly this flow. However, this doesn't solve entirely the memory leaking problem but, regardless of that, it's a good practice to do this.  

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes/features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
