### PR TITLE
Null check on frame in MasterDetailsView

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -153,7 +153,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 }
 
                 _frame = this.FindAscendant<Frame>();
-                _frame.Navigating += OnFrameNavigating;
+                if (_frame != null)
+                {
+                    _frame.Navigating += OnFrameNavigating;
+                }
 
                 _selectionStateGroup = (VisualStateGroup)GetTemplateChild(SelectionStates);
                 if (_selectionStateGroup != null)


### PR DESCRIPTION
Issue: #
https://github.com/Microsoft/WindowsCommunityToolkit/issues/2279

## PR Type
What kind of change does this PR introduce?
 - Bugfix


## What is the current behavior?
If MasterDetailsView doesn't have a Visual ancestor that is a Frame, it throws an error whilst hooking navigation events.

## What is the new behavior?
Check for null, skip navigation hook.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [x] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes