### PR TITLE
Remove Json.NET from Parsers library

### DIFF
--- a/Microsoft.Toolkit.Parsers/Markdown/Inlines/LinkAnchorInline.cs
+++ b/Microsoft.Toolkit.Parsers/Markdown/Inlines/LinkAnchorInline.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Xml;
+using System.Xml.Linq;
 using Microsoft.Toolkit.Parsers.Markdown.Helpers;
 
 namespace Microsoft.Toolkit.Parsers.Markdown.Inlines
@@ -85,10 +86,12 @@ namespace Microsoft.Toolkit.Parsers.Markdown.Inlines
 
             try
             {
-                var xml = new XmlDocument();
-                xml.LoadXml(contents);
-                var attr = xml.DocumentElement.Attributes.GetNamedItem("name");
-                link = attr.Value;
+                var xml = XElement.Parse(contents);
+                var attr = xml.Attribute("name");
+                if (attr != null)
+                {
+                    link = attr.Value;
+                }
             }
             catch
             {

--- a/Microsoft.Toolkit.Parsers/Microsoft.Toolkit.Parsers.csproj
+++ b/Microsoft.Toolkit.Parsers/Microsoft.Toolkit.Parsers.csproj
@@ -11,10 +11,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-  </ItemGroup>
-  
-  <ItemGroup>
     <ProjectReference Include="..\Microsoft.Toolkit\Microsoft.Toolkit.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Issue: #2288
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Microsoft.Toolkit.Parsers has a reference to Json.Net but does not use Json.Net

## What is the new behavior?
Removes Json.Net

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
