### PR TITLE
AdvancedCollectionView - Re sort all items when PropertyChanged notifications has no parameters 

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -485,6 +485,10 @@ namespace Microsoft.Toolkit.Uwp.UI
 
                 OnVectorChanged(new VectorChangedEventArgs(CollectionChange.ItemInserted, targetIndex, item));
             }
+            else if (e.PropertyName == "" || e.PropertyName == null)
+            {
+                HandleSourceChanged();
+            }
         }
 
         private void AttachPropertyChangedHandler(IEnumerable items)


### PR DESCRIPTION
Issue: #2143 

## PR Type
What kind of change does this PR introduce?

Bugfix

## What is the current behavior?
When you modify an element used by an AdvancedCollectionView and it has the INotifyPropertyChanged interface implemented with the onPropertyChange method without the propertyName parameter, it doesn't resort. This is because the AdvancedColectionView's treatment for PropertyChanged notifications doesn't control the case in which it has an empty or null propertyName, and therefore, ignores the situation.

## What is the new behavior?
The controls covers the case which the onPropertyChange method has no propertyName 
![refreshes-with-notify-changed-empty](https://user-images.githubusercontent.com/3893598/42841270-e5f03cda-89df-11e8-9589-4dbcd1f768e3.gif)

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x ] Contains **NO** breaking changes
