### PR TITLE
deprecated publish_actions and dependencies

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookCode.bind
@@ -13,14 +13,8 @@ ListView.ItemsSource = await FacebookService.Instance.RequestAsync(FacebookDataC
 // Get current user profile picture
 ProfileImage.DataContext = await FacebookService.Instance.GetUserPictureInfoAsync();
 
-// Post a message on your wall
-await FacebookService.Instance.PostToFeedAsync(TitleText.Text, MessageText.Text, DescriptionText.Text, UrlText.Text);
-
 // Post a message on your wall using Facebook Dialog
 await FacebookService.Instance.PostToFeedWithDialogAsync(TitleText.Text, DescriptionText.Text, UrlText.Text);
-
-// Post a message with a picture on your wall
-await FacebookService.Instance.PostPictureToFeedAsync(TitleText.Text, picture.Name, stream);
 
 // Get current user's photo albums
 await FacebookService.Instance.GetUserAlbumsAsync();

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookPage.xaml
@@ -216,11 +216,6 @@
                                 <ColumnDefinition />
                                 <ColumnDefinition />
                             </Grid.ColumnDefinitions>
-
-                            <Grid.RowDefinitions>
-                                <RowDefinition />
-                                <RowDefinition />
-                            </Grid.RowDefinitions>
                             
                             <TextBox x:Name="UrlText"
                                     Header="Url"
@@ -231,17 +226,6 @@
                                     Click="ShareButton_OnClick"
                                     VerticalAlignment="Bottom"
                                     Content="Share with dialog" />
-                            <TextBox x:Name="TitleText"
-                                    Grid.Row="1"
-                                    Margin="0,12,0,0"
-                                    Header="Title" />
-                            <Button x:Name="SharePictureButton"
-                                    Grid.Row="1"
-                                    Grid.Column="1"
-                                    Margin="12,0,0,0"
-                                    VerticalAlignment="Bottom"
-                                    Click="SharePictureButton_OnClick"
-                                    Content="Share directly with picture" />
                         </Grid>
                     </Grid>
 

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookPage.xaml.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             }
 
             Shell.Current.DisplayWaitRing = true;
-            FacebookService.Instance.Initialize(AppIDText.Text, FacebookPermissions.PublicProfile | FacebookPermissions.UserPosts | FacebookPermissions.PublishActions | FacebookPermissions.UserPhotos);
+            FacebookService.Instance.Initialize(AppIDText.Text, FacebookPermissions.PublicProfile | FacebookPermissions.UserPosts | FacebookPermissions.UserPhotos);
             if (!await FacebookService.Instance.LoginAsync())
             {
                 ShareBox.Visibility = Visibility.Collapsed;
@@ -101,30 +101,6 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             await FacebookService.Instance.PostToFeedWithDialogAsync(UrlText.Text);
             var message = new MessageDialog("Post sent to facebook");
             await message.ShowAsync();
-        }
-
-        private async void SharePictureButton_OnClick(object sender, RoutedEventArgs e)
-        {
-            if (!await Tools.CheckInternetConnectionAsync())
-            {
-                return;
-            }
-
-            var openPicker = new FileOpenPicker
-            {
-                ViewMode = PickerViewMode.Thumbnail,
-                SuggestedStartLocation = PickerLocationId.PicturesLibrary
-            };
-            openPicker.FileTypeFilter.Add(".jpg");
-            openPicker.FileTypeFilter.Add(".png");
-            StorageFile picture = await openPicker.PickSingleFileAsync();
-            if (picture != null)
-            {
-                using (var stream = await picture.OpenReadAsync())
-                {
-                    await FacebookService.Instance.PostPictureToFeedAsync(TitleText.Text, picture.Name, stream);
-                }
-            }
         }
 
         private void CredentialsBoxExpandButton_OnClick(object sender, RoutedEventArgs e)

--- a/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookService.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.Foundation.Metadata;
 using Windows.Security.Authentication.Web;
 using Windows.Storage.Streams;
 using winsdkfb;
@@ -50,7 +51,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         /// <param name="oAuthTokens">Token instance.</param>
         /// <param name="requiredPermissions">List of required required permissions. public_profile and user_posts permissions will be used by default.</param>
         /// <returns>Success or failure.</returns>
-        public bool Initialize(FacebookOAuthTokens oAuthTokens, FacebookPermissions requiredPermissions = FacebookPermissions.PublicProfile | FacebookPermissions.UserPosts | FacebookPermissions.PublishActions)
+        public bool Initialize(FacebookOAuthTokens oAuthTokens, FacebookPermissions requiredPermissions = FacebookPermissions.PublicProfile | FacebookPermissions.UserPosts)
         {
             if (oAuthTokens == null)
             {
@@ -67,7 +68,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         /// <param name="requiredPermissions">List of required required permissions. public_profile and user_posts permissions will be used by default.</param>
         /// <param name="windowsStoreId">Windows Store SID</param>
         /// <returns>Success or failure.</returns>
-        public bool Initialize(string appId, FacebookPermissions requiredPermissions = FacebookPermissions.PublicProfile | FacebookPermissions.UserPosts | FacebookPermissions.PublishActions, string windowsStoreId = null)
+        public bool Initialize(string appId, FacebookPermissions requiredPermissions = FacebookPermissions.PublicProfile | FacebookPermissions.UserPosts, string windowsStoreId = null)
         {
             if (string.IsNullOrEmpty(appId))
             {
@@ -395,6 +396,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         /// </summary>
         /// <param name="link">Link contained as part of the post. Cannot be null.</param>
         /// <returns>Task to support await of async call.</returns>
+        [Deprecated("The underlying publish_action permission is no longer supported by Facebook. Please see https://developers.facebook.com/blog/post/2018/04/24/new-facebook-platform-product-changes-policy-updates/ for details.", DeprecationType.Deprecate, 4)]
         public async Task<bool> PostToFeedAsync(string link)
         {
             if (Provider.LoggedIn)
@@ -466,6 +468,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         /// <param name="pictureName">Picture name.</param>
         /// <param name="pictureStream">Picture stream to upload.</param>
         /// <returns>Return ID of the picture</returns>
+        [Deprecated("The underlying publish_action permission is no longer supported by Facebook. Please see https://developers.facebook.com/blog/post/2018/04/24/new-facebook-platform-product-changes-policy-updates/ for details.", DeprecationType.Deprecate, 4)]
         public async Task<string> PostPictureToFeedAsync(string title, string pictureName, IRandomAccessStreamWithContentType pictureStream)
         {
             if (pictureStream == null)

--- a/docs/services/Facebook.md
+++ b/docs/services/Facebook.md
@@ -79,14 +79,8 @@ ListView.ItemsSource = await FacebookService.Instance.RequestAsync(FacebookDataC
 // Get current user profile picture
 ProfileImage.DataContext = await FacebookService.Instance.GetUserPictureInfoAsync();
 
-// Post a message on your wall
-await FacebookService.Instance.PostToFeedAsync(TitleText.Text, MessageText.Text, DescriptionText.Text, UrlText.Text);
-
 // Post a message on your wall using Facebook Dialog
 await FacebookService.Instance.PostToFeedWithDialogAsync(TitleText.Text, DescriptionText.Text, UrlText.Text);
-
-// Post a message with a picture on your wall
-await FacebookService.Instance.PostToFeedAsync(TitleText.Text, MessageText.Text, DescriptionText.Text, picture.Name, stream);
 
 // Get current user's photo albums
 await FacebookService.Instance.GetUserAlbumsAsync();
@@ -109,14 +103,8 @@ ListView.ItemsSource = Await FacebookService.Instance.RequestAsync(FacebookDataC
 ' Get current user profile picture
 ProfileImage.DataContext = Await FacebookService.Instance.GetUserPictureInfoAsync()
 
-' Post a message on your wall
-Await FacebookService.Instance.PostToFeedAsync(TitleText.Text, MessageText.Text, DescriptionText.Text, UrlText.Text)
-
 ' Post a message on your wall using Facebook Dialog
 Await FacebookService.Instance.PostToFeedWithDialogAsync(TitleText.Text, DescriptionText.Text, UrlText.Text)
-
-' Post a message with a picture on your wall
-Await FacebookService.Instance.PostToFeedAsync(TitleText.Text, MessageText.Text, DescriptionText.Text, picture.Name, Stream)
 
 ' Get current user's photo albums
 Await FacebookService.Instance.GetUserAlbumsAsync()
@@ -281,9 +269,7 @@ Class for connecting to Facebook
 | GetUserPhotosByAlbumIdAsync(string, int, string) | Task<List<FacebookPhoto>> | Retrieves list of user photos by album id |
 | GetUserPhotosByAlbumIdAsync(string, int, int, string) | Task<IncrementalLoadingCollection<FacebookRequestSource<FacebookPhoto>, FacebookPhoto>> | Retrieves list of user photos by album id |
 | GetPhotoByPhotoIdAsync(string) | Task<FacebookPhoto> | Retrieves a photo by id |
-| PostToFeedAsync(string) | Task<bool> | Enables direct posting data to the timeline |
 | PostToFeedWithDialogAsync(string) | Task<bool> | Enables posting data to the timeline using Facebook dialog |
-| PostPictureToFeedAsync(string, string, IRandomAccessStreamWithContentType) | Task<string> | Enables posting a picture to the timeline |
 
 ## Sample Code
 


### PR DESCRIPTION
Issue: #2273 
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
Other... Please describe: Feature deprecation


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
See 2273
Facebook deprecated the publish_actions permission - the toolkit Facebook service and Facebook app fail to login/post actions.

## What is the new behavior?
Deprecated the methods that depend on publish_actions, removed features from the sample app that leveraged the publish_actions feature.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [X] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
The FacebookService methods affected have been marked deprecated - they should fail silently if called.  Apps consuming the service will need to explicitly stop initializing with the PublishActions permission otherwise login will eventually fail.  Posts will now need to be leveraged via the supported PostToFeedWithDialogAsync method - this will likely not satisfy all existing scenarios and so future work may be required to increase the features supported by this method.

## Other information
