### PR TITLE
Update Win32 project to use Insiders SDK 17713

### DIFF
--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/WinRT/WebViewControlPermissionType.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/WinRT/WebViewControlPermissionType.cs
@@ -41,5 +41,11 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
         /// Permission is for screen.
         /// </summary>
         Screen,
+
+        /// <summary>
+        /// Permissions is for immersive view.
+        /// </summary>
+        /// <remarks>New for RS5</remarks>
+        ImmersiveView,
     }
 }

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Microsoft.Toolkit.Win32.UI.Controls.csproj
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Microsoft.Toolkit.Win32.UI.Controls.csproj
@@ -17,14 +17,12 @@
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <!--
     When changing this value, ensure the SDK is installed with the build process.
-    Need to check several files:
-      - /.vsts-ci.yml
-      - /.vsts-pr.yml
+      - /build/vsts-build.yml
 
     This also needs to be installed on your local machine. Can do this with PowerShell:
-      ./build/Install-WindowsSDKISO.ps1 17704
+      ./build/Install-WindowsSDKISO.ps1 17713
     -->
-    <TargetPlatformVersion>10.0.17704.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.17713.0</TargetPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/build/vsts-build.yml
+++ b/build/vsts-build.yml
@@ -26,7 +26,7 @@ steps:
   displayName: Set Version
   condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
       
-- powershell: .\build\Install-WindowsSdkISO.ps1 17704
+- powershell: .\build\Install-WindowsSdkISO.ps1 17713
   displayName: Insider SDK
 
 - powershell: .\build\build.ps1 -target=Package


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Missing API for WebView (ImmersiveView permission)

## What is the new behavior?
Updating SDK to latest Insiders released version

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
