### PR TITLE
Enabling "TreatWarningsAsErrors" on release builds 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -107,6 +107,9 @@
         <Page Include="**\*.xaml" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" SubType="Designer" Generator="MSBuild:Compile" />
         <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
       </ItemGroup>
+      <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+      </PropertyGroup>
     </When>
   </Choose>
 

--- a/Microsoft.Toolkit.Services/Services/MicrosoftGraph/MicrosoftGraphService.cs
+++ b/Microsoft.Toolkit.Services/Services/MicrosoftGraph/MicrosoftGraphService.cs
@@ -191,7 +191,9 @@ namespace Microsoft.Toolkit.Services.MicrosoftGraph
         /// Logout the current user
         /// </summary>
         /// <returns>success or failure</returns>
+#pragma warning disable CS1998
         public virtual async Task<bool> Logout()
+#pragma warning restore CS1998
         {
             if (!IsInitialized)
             {

--- a/Microsoft.Toolkit.Services/Services/OneDrive/OneDriveStorageItem.cs
+++ b/Microsoft.Toolkit.Services/Services/OneDrive/OneDriveStorageItem.cs
@@ -111,7 +111,6 @@ namespace Microsoft.Toolkit.Services.OneDrive
         /// </summary>
         public IBaseClient Provider { get; private set; }
 
-
         /// <summary>
         /// Gets an instance of a DriveItem
         /// </summary>

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.cs
@@ -18,10 +18,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
     /// </summary>
     public static partial class AnimationExtensions
     {
-        /// <summary>
-        /// A cached dictionary mapping easings to bezier control points
-        /// </summary>
+#pragma warning disable SA1008 // Opening parenthesis must be spaced correctly
+#pragma warning disable SA1009 // Closing parenthesis must be spaced correctly
+                              /// <summary>
+                              /// A cached dictionary mapping easings to bezier control points
+                              /// </summary>
         private static readonly Dictionary<(string, EasingMode), (Vector2, Vector2)> _compositionEasingFunctions = new Dictionary<(string, EasingMode), (Vector2, Vector2)>();
+#pragma warning restore SA1009 // Closing parenthesis must be spaced correctly
+#pragma warning restore SA1008 // Opening parenthesis must be spaced correctly
 
         /// <summary>
         /// Gets or sets the default EasingType used for storyboard animations
@@ -123,7 +127,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             {
                 // In order to generate a usable hashcode for our ValueTuple without collisions
                 // we can't use enum values for both type & mode, so we have to string one of them.
+#pragma warning disable SA1008 // Opening parenthesis must be spaced correctly
                 _compositionEasingFunctions[(type.ToString(), mode)] = (p1, p2);
+#pragma warning restore SA1008 // Opening parenthesis must be spaced correctly
             }
 
             Add(EasingType.Cubic, EasingMode.EaseOut, new Vector2(0.215f, 0.61f), new Vector2(0.355f, 1f));
@@ -178,7 +184,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             // Pay-per-play caching of easing functions
             EnsureEasingsCached();
 
-            if (_compositionEasingFunctions.TryGetValue((easingType.ToString(), easingMode), out (Vector2, Vector2) points))
+            if (_compositionEasingFunctions.TryGetValue((easingType.ToString(), easingMode), out(Vector2, Vector2) points))
             {
                 return compositor.CreateCubicBezierEasingFunction(points.Item1, points.Item2);
             }

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Microsoft.Toolkit.Uwp.UI.Animations.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Microsoft.Toolkit.Uwp.UI.Animations.csproj
@@ -7,16 +7,15 @@
     <PackageTags>UWP Toolkit Windows Animations Composition</PackageTags>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NoWarn>CS8002</NoWarn>
+  </PropertyGroup>
 
   <ItemGroup>
-    
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    
     <PackageReference Include="Win2D.uwp" Version="1.21.0" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="1.1.0" />
-
     <ProjectReference Include="..\Microsoft.Toolkit.Uwp.UI\Microsoft.Toolkit.Uwp.UI.csproj" />
-
   </ItemGroup>
 
 </Project>

--- a/Microsoft.Toolkit.Uwp.UI.Controls.Graph/AadLogin/AadLogin.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Graph/AadLogin/AadLogin.Properties.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Toolkit.Services.MicrosoftGraph;
-using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Imaging;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/CameraPreview/CameraPreview.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/CameraPreview/CameraPreview.cs
@@ -154,7 +154,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     {
                         InvokePreviewFailed("CameraPreview is only supported on the April 2018 Windows 10 Update or later");
                     }
-
                 }
             }
             catch (Exception ex)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InfiniteCanvas/JsonConverters/SerializableStroke.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InfiniteCanvas/JsonConverters/SerializableStroke.cs
@@ -5,8 +5,6 @@
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.Serialization;
-using Windows.Foundation;
-using Windows.UI;
 using Newtonsoft.Json;
 using Windows.UI.Input.Inking;
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
@@ -5,14 +5,15 @@
     <Title>Windows Community Toolkit Controls</Title>
     <Description>This library provides XAML user controls. It is part of the Windows Community Toolkit.</Description>
     <PackageTags>UWP Toolkit Windows Controls XAML Hamburger Range WrapPanel Adaptive Markdown</PackageTags>
+  </PropertyGroup>
 
+  <PropertyGroup>
+    <NoWarn>CS8002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-
     <PackageReference Include="ColorCode.UWP" Version="2.0.3" />
     <PackageReference Include="Robmikh.CompositionSurfaceFactory" Version="0.7.3" />
-
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <ProjectReference Include="..\Microsoft.Toolkit.Uwp.UI.Animations\Microsoft.Toolkit.Uwp.UI.Animations.csproj" />
     <ProjectReference Include="..\Microsoft.Toolkit.Parsers\Microsoft.Toolkit.Parsers.csproj" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             // Measure our min/max text longest value so we can avoid the length of the scrolling reason shifting in size during use.
             var tb = new TextBlock { Text = Maximum.ToString() };
-            tb.Measure(new Size(Double.PositiveInfinity, Double.PositiveInfinity));
+            tb.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
 
             base.OnApplyTemplate();
         }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
 - Code style update (formatting)
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Style warnings should stop the build when building in Release but currently they do not

## What is the new behavior?
Style warnings will not break the build when building in release. This will ensure we do not merge code with warnings as part of pull requests
