### PR TITLE
WPF WebView: Protect actions and delay navigation until last moment 3.0.x

### DIFF
--- a/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebView.cs
+++ b/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebView.cs
@@ -515,6 +515,13 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         public string InvokeScript(string scriptName)
         {
             VerifyAccess();
+
+            do
+            {
+                Dispatcher.CurrentDispatcher.DoEvents();
+            }
+            while (!_initializationComplete.WaitOne(InitializationBlockingTime));
+
             Verify.IsNotNull(_webViewControl);
             return _webViewControl?.InvokeScript(scriptName);
         }
@@ -523,6 +530,13 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         public string InvokeScript(string scriptName, params string[] arguments)
         {
             VerifyAccess();
+
+            do
+            {
+                Dispatcher.CurrentDispatcher.DoEvents();
+            }
+            while (!_initializationComplete.WaitOne(InitializationBlockingTime));
+
             Verify.IsNotNull(_webViewControl);
             return _webViewControl?.InvokeScript(scriptName, arguments);
         }
@@ -531,6 +545,13 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         public string InvokeScript(string scriptName, IEnumerable<string> arguments)
         {
             VerifyAccess();
+
+            do
+            {
+                Dispatcher.CurrentDispatcher.DoEvents();
+            }
+            while (!_initializationComplete.WaitOne(InitializationBlockingTime));
+
             Verify.IsNotNull(_webViewControl);
             return _webViewControl?.InvokeScript(scriptName, arguments);
         }
@@ -539,6 +560,13 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         public Task<string> InvokeScriptAsync(string scriptName)
         {
             VerifyAccess();
+
+            do
+            {
+                Dispatcher.CurrentDispatcher.DoEvents();
+            }
+            while (!_initializationComplete.WaitOne(InitializationBlockingTime));
+
             Verify.IsNotNull(_webViewControl);
             return _webViewControl?.InvokeScriptAsync(scriptName);
         }
@@ -547,6 +575,13 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         public Task<string> InvokeScriptAsync(string scriptName, params string[] arguments)
         {
             VerifyAccess();
+
+            do
+            {
+                Dispatcher.CurrentDispatcher.DoEvents();
+            }
+            while (!_initializationComplete.WaitOne(InitializationBlockingTime));
+
             Verify.IsNotNull(_webViewControl);
             return _webViewControl?.InvokeScriptAsync(scriptName, arguments);
         }
@@ -555,6 +590,13 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         public Task<string> InvokeScriptAsync(string scriptName, IEnumerable<string> arguments)
         {
             VerifyAccess();
+
+            do
+            {
+                Dispatcher.CurrentDispatcher.DoEvents();
+            }
+            while (!_initializationComplete.WaitOne(InitializationBlockingTime));
+
             Verify.IsNotNull(_webViewControl);
             return _webViewControl?.InvokeScriptAsync(scriptName, arguments);
         }
@@ -696,10 +738,12 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
                         scriptNotifyAllowed = IsScriptNotifyAllowed;
                     }
 
-                    _webViewControl.Source = source;
                     _webViewControl.Settings.IsJavaScriptEnabled = javaScriptEnabled;
                     _webViewControl.Settings.IsIndexedDBEnabled = indexDBEnabled;
                     _webViewControl.Settings.IsScriptNotifyAllowed = scriptNotifyAllowed;
+
+                    // This will cause a navigate, make last property set
+                    _webViewControl.Source = source;
 
                     _initializationState = InitializationState.IsInitialized;
                     _initializationComplete.Set();


### PR DESCRIPTION
Issue: #2346 
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
An issue may occur where methods, such as InvokeScript/InvokeScriptAsync, are permitted to be invoked prior to the WebView completing initialization. As such, properties may not yet be set for permitting JavaScript or ScriptNotify, causing inconsistencies with application behavior.

Additionally, the Source property is set, causing an immediate navigation before other properties are also set. The code has been updated for WPF to follow a similar order for WinForms.

## What is the new behavior?
Execution cannot continue until the control is verified to be completely loaded. Additionally, navigation (setting `Source` property), is the last property set during initialization to ensure all other behaviors are set prior to initiating any such navigation.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
