### PR TITLE
Add Close before HWND destroyed (4.0.0)

### DIFF
--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.cs
@@ -57,6 +57,26 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
 
         internal WebViewControlHost Host => _webViewControl;
 
+        /// <inheritdoc />
+        protected override void DestroyHandle()
+        {
+            // In RS4 if a component is not completely cleaned up it could cause a hang, which was fixed in RS5
+            // For compatability with RS4, call Close to remove the HWNDs to avoid a possible message storm and UI lock up
+            Close();
+
+            base.DestroyHandle();
+        }
+
+        /// <inheritdoc />
+        protected override void OnHandleDestroyed(EventArgs e)
+        {
+            // In RS4 if a component is not completely cleaned up it could cause a hang, which was fixed in RS5
+            // For compatability with RS4, call Close to remove the HWNDs to avoid a possible message storm and UI lock up
+            Close();
+
+            base.OnHandleDestroyed(e);
+        }
+
         /// <summary>
         /// Gets a value indicating whether <see cref="WebView"/> is supported in this environment.
         /// </summary>


### PR DESCRIPTION
Issue: #2337
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
During the disposal process the HWND for the control is destroyed, leaving an orphaned HWND core window. In RS4 this could case a lock up since it was expected that the Close method on WebViewControl would always be closed. During RS5 this was updated to ensure that Close is always called, even if the hosting process crashes or one of the supporting processes is terminated unexpectedly.

## What is the new behavior?
This change intercepts the DestoryHandle and OnHandleDestoryed methods of the Windows Forms WebView control to first call Close method. This starts a synchronous shutdown of all processes and unparents the HWNDs. By the time the actual disposal comes around, the control and its processes are already cleaned up and the UI remains responsive.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
Note that this change is to work around a RS4 bug; however, its inclusion for RS5 does not impede compatibility or introduce any undesired consequences.

Related to #2362 

CC @MaxBarraclough 