### PR TITLE
Deprecate NavigationView extension

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/samples.json
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/samples.json
@@ -918,8 +918,9 @@
         "XamlCodeFile": "NavigationViewStylesXaml.bind",
         "DocumentationUrl": "https://raw.githubusercontent.com/Microsoft/WindowsCommunityToolkit/master/docs/extensions/NavigationView.md",
         "Icon": "/SamplePages/NavigationViewStyles/NavigationViewStyles.png",
-        "About": "Style extensions for the NavigationView to appear like the one used by Visual Studio Code.",
-        "BadgeUpdateVersionRequired": "Fall Creators Update required",
+        "About": "The NavigationView extension will be removed in a future major release.",
+        "BadgeUpdateVersionRequired": "DEPRECATED",
+        "DeprecatedWarning": "The NavigationView extension will be removed in a future major release.",
         "ApiCheck": "Windows.UI.Xaml.Controls.NavigationView",
         "CodeUrl": "https://github.com/Microsoft/UWPCommunitToolkit/tree/master/Microsoft.Toolkit.Uwp.UI/Extensions/NavigationView"
       },

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/NavigationView/NavigationViewExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/NavigationView/NavigationViewExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
@@ -12,6 +13,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
     /// Set of extensions for the <see cref="NavigationView"/> control.
     /// </summary>
     [Bindable]
+    [Obsolete("The Navigation View extension will be removed in a future major release.")]
     public static class NavigationViewExtensions
     {
         // Name of Content area in NavigationView Template.

--- a/docs/extensions/NavigationView.md
+++ b/docs/extensions/NavigationView.md
@@ -7,8 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # NavigationView Styles
 
-[!NOTE]
-The NavigationView extension will be removed in a future major release.
+[!NOTE] The NavigationView extension will be removed in a future major release.
 
 <!-- Describe your control -->
 The [NavigationView Styles](https://docs.microsoft.com/en-us/windows/uwpcommunitytoolkit/extensions/navigationview) are a set of styles and extensions to reskin a `NavigationView` to look and behave like the `Activity Bar` and `Side Bar` in *Visual Studio Code*.

--- a/docs/extensions/NavigationView.md
+++ b/docs/extensions/NavigationView.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # NavigationView Styles
 
-[!NOTE] The NavigationView extension will be removed in a future major release.
+> [!NOTE] The NavigationView extension will be removed in a future major release.
 
 <!-- Describe your control -->
 The [NavigationView Styles](https://docs.microsoft.com/en-us/windows/uwpcommunitytoolkit/extensions/navigationview) are a set of styles and extensions to reskin a `NavigationView` to look and behave like the `Activity Bar` and `Side Bar` in *Visual Studio Code*.

--- a/docs/extensions/NavigationView.md
+++ b/docs/extensions/NavigationView.md
@@ -6,6 +6,10 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 ---
 
 # NavigationView Styles
+
+[!NOTE]
+The NavigationView extension will be removed in a future major release.
+
 <!-- Describe your control -->
 The [NavigationView Styles](https://docs.microsoft.com/en-us/windows/uwpcommunitytoolkit/extensions/navigationview) are a set of styles and extensions to reskin a `NavigationView` to look and behave like the `Activity Bar` and `Side Bar` in *Visual Studio Code*.
 


### PR DESCRIPTION
Issue: #2242 
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

 - Documentation content changes
 - Sample app changes


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
Added the deprecated warning to NavigationView extension

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
