### PR TITLE
Fix deadlock on InvokeScript (4.0.0)

### DIFF
--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/WinRT/WebViewControlHost.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/WinRT/WebViewControlHost.cs
@@ -414,15 +414,6 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
         }
 
         /// <exception cref="InvalidOperationException">When the underlying <see cref="WebViewControl"/> is not yet initialized.</exception>
-        internal string InvokeScript(string scriptName) => InvokeScript(scriptName, null);
-
-        /// <exception cref="InvalidOperationException">When the underlying <see cref="WebViewControl"/> is not yet initialized.</exception>
-        internal string InvokeScript(string scriptName, params string[] arguments) => InvokeScript(scriptName, (IEnumerable<string>)arguments);
-
-        /// <exception cref="InvalidOperationException">When the underlying <see cref="WebViewControl"/> is not yet initialized.</exception>
-        internal string InvokeScript(string scriptName, IEnumerable<string> arguments) => InvokeScriptAsync(scriptName, arguments).GetAwaiter().GetResult();
-
-        /// <exception cref="InvalidOperationException">When the underlying <see cref="WebViewControl"/> is not yet initialized.</exception>
         internal Task<string> InvokeScriptAsync(string scriptName) => InvokeScriptAsync(scriptName, null);
 
         /// <exception cref="InvalidOperationException">When the underlying <see cref="WebViewControl"/> is not yet initialized.</exception>

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/TaskExtensions.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/TaskExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Threading;
+
+namespace System.Threading.Tasks
+{
+    /// <summary>
+    /// Contains extensions to process a task within a nested Windows Presentation Foundation (WPF) message loop
+    /// </summary>
+    internal static partial class TaskExtensions
+    {
+        public static T WaitWithNestedMessageLoop<T>(this Task<T> task, Dispatcher dispatcher)
+        {
+            // Check if we have a valid dispatcher
+            if (dispatcher != null
+                && !dispatcher.HasShutdownStarted
+                && !dispatcher.HasShutdownFinished)
+            {
+                // Set the priority to ContextIdle to force the queue to flush higher priority events
+                var frame = new DispatcherFrame();
+                task.ContinueWith(_ => frame.Continue = false, TaskScheduler.Default);
+                Dispatcher.PushFrame(frame);
+            }
+
+            return task.Result;
+        }
+    }
+}

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebView.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebView.cs
@@ -521,34 +521,10 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         }
 
         /// <inheritdoc />
-        public string InvokeScript(string scriptName)
-        {
-            VerifyAccess();
-
-            do
-            {
-                Dispatcher.CurrentDispatcher.DoEvents();
-            }
-            while (!_initializationComplete.WaitOne(InitializationBlockingTime));
-
-            Verify.IsNotNull(_webViewControl);
-            return _webViewControl?.InvokeScript(scriptName);
-        }
+        public string InvokeScript(string scriptName) => InvokeScript(scriptName, null);
 
         /// <inheritdoc />
-        public string InvokeScript(string scriptName, params string[] arguments)
-        {
-            VerifyAccess();
-
-            do
-            {
-                Dispatcher.CurrentDispatcher.DoEvents();
-            }
-            while (!_initializationComplete.WaitOne(InitializationBlockingTime));
-
-            Verify.IsNotNull(_webViewControl);
-            return _webViewControl?.InvokeScript(scriptName, arguments);
-        }
+        public string InvokeScript(string scriptName, params string[] arguments) => InvokeScript(scriptName, (IEnumerable<string>)arguments);
 
         /// <inheritdoc />
         public string InvokeScript(string scriptName, IEnumerable<string> arguments)
@@ -562,7 +538,10 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
             while (!_initializationComplete.WaitOne(InitializationBlockingTime));
 
             Verify.IsNotNull(_webViewControl);
-            return _webViewControl?.InvokeScript(scriptName, arguments);
+
+            // WebViewControlHost ends up calling InvokeScriptAsync anyway
+            // The problem we have is that InvokeScript could be called from a UI thread and waiting for an async result that could lead to deadlock
+            return InvokeScriptAsync(scriptName, arguments).WaitWithNestedMessageLoop(Dispatcher.CurrentDispatcher);
         }
 
         /// <inheritdoc />

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WinForms/TaskExtensions.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WinForms/TaskExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms;
+
+namespace System.Threading.Tasks
+{
+    /// <summary>
+    /// Contains extensions to process a task within a nested Windows Forms message loop
+    /// </summary>
+    internal static partial class TaskExtensions
+    {
+        public static T WaitWithNestedMessageLoop<T>(this Task<T> task)
+        {
+            while (!task.IsCompleted)
+            {
+                Application.DoEvents();
+            }
+
+            return task.Result;
+        }
+    }
+}

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.cs
@@ -469,13 +469,18 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
         public WebViewControlDeferredPermissionRequest GetDeferredPermissionRequestById(uint id) => _webViewControl?.GetDeferredPermissionRequestById(id);
 
         /// <inheritdoc />
-        public string InvokeScript(string scriptName) => _webViewControl?.InvokeScript(scriptName);
+        public string InvokeScript(string scriptName) => InvokeScript(scriptName, null);
 
         /// <inheritdoc />
-        public string InvokeScript(string scriptName, params string[] arguments) => _webViewControl?.InvokeScript(scriptName, arguments);
+        public string InvokeScript(string scriptName, params string[] arguments) => InvokeScript(scriptName, (IEnumerable<string>)arguments);
 
         /// <inheritdoc />
-        public string InvokeScript(string scriptName, IEnumerable<string> arguments) => _webViewControl?.InvokeScript(scriptName, arguments);
+        public string InvokeScript(string scriptName, IEnumerable<string> arguments)
+        {
+            // WebViewControlHost ends up calling InvokeScriptAsync anyway
+            // The problem we have is that InvokeScript could be called from a UI thread and waiting for an async result that could lead to deadlock
+            return InvokeScriptAsync(scriptName, arguments).WaitWithNestedMessageLoop();
+        }
 
         /// <inheritdoc />
         public Task<string> InvokeScriptAsync(string scriptName) => _webViewControl?.InvokeScriptAsync(scriptName);

--- a/Microsoft.Toolkit.Win32/Tests/UnitTests.WebView.WinForms/FunctionalTests/InvokeScript/InvokeScriptTests.cs
+++ b/Microsoft.Toolkit.Win32/Tests/UnitTests.WebView.WinForms/FunctionalTests/InvokeScript/InvokeScriptTests.cs
@@ -9,6 +9,37 @@ using Should;
 
 namespace Microsoft.Toolkit.Win32.UI.Controls.Test.WinForms.WebView.FunctionalTests.InvokeScript
 {
+    // Issue #2367 - Deadlock when UI thread calls multiple InvokeScript with return value
+    [TestClass]
+    public class InvokeScriptMultipleTimesOnUIThread : HostFormWebViewContextSpecification
+    {
+        private string _actual;
+
+        protected override void Given()
+        {
+            base.Given();
+
+            WebView.NavigationCompleted += (o, e) =>
+            {
+                _actual = WebView.InvokeScript("eval", "document.title");
+                _actual = WebView.InvokeScript("eval", "document.title");
+                _actual = WebView.InvokeScript("eval", "document.title");
+                Form.Close();
+            };
+        }
+
+        protected override void When()
+        {
+            NavigateAndWaitForFormClose(TestConstants.Uris.ExampleCom);
+        }
+
+        [TestMethod]
+        public void JavaScriptReturnsWithoutDeadlock()
+        {
+            _actual.ShouldEqual("Example Domain");
+        }
+    }
+
     [TestClass]
     public class InvokeScriptAsyncNoArgumentsTests : HostFormWebViewContextSpecification
     {


### PR DESCRIPTION
Issue: #2367
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When calling WebView.InvokeScript from the UI thread, a deadlock may occur when the asynchronous task is captured within the UI context. Since each thread is waiting for the each other, the deadlock occurs.


## What is the new behavior?
An attempt to move the thread execution to the thread pool causes a similar issue, so the task is moved to a message loop to keep the UI responsive while the task is completed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
CC @PoulBak
Resolves #2367