### PR TITLE
Add tests for NavigateWithHttpMessage

### DIFF
--- a/Microsoft.Toolkit.Win32/Tests/UnitTests.WebView.WinForms/FunctionalTests/Navigation/NavigateWithHttpMessageTests.cs
+++ b/Microsoft.Toolkit.Win32/Tests/UnitTests.WebView.WinForms/FunctionalTests/Navigation/NavigateWithHttpMessageTests.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Microsoft.Toolkit.Win32.UI.Controls.Test.WebView.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Should;
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Test.WinForms.WebView.FunctionalTests.Navigation
+{
+    [TestClass]
+    [TestCategory(TestConstants.Categories.Nav)]
+    public class HTTP_GET : HostFormWebViewContextSpecification
+    {
+        private bool _success;
+
+        protected override void Given()
+        {
+            base.Given();
+            WebView.NavigationCompleted += (o, e) =>
+            {
+                _success = e.IsSuccess;
+                Form.Close();
+            };
+        }
+
+        protected override void When()
+        {
+            NavigateAndWaitForFormClose(TestConstants.Uris.ExampleCom, HttpMethod.Get);
+        }
+
+        [TestMethod]
+        [Timeout(TestConstants.Timeouts.Longest)]
+        public void NavigationShouldComplete()
+        {
+            _success.ShouldBeTrue();
+        }
+    }
+
+    [TestClass]
+    [TestCategory(TestConstants.Categories.Nav)]
+    public class HTTP_POST : HostFormWebViewContextSpecification
+    {
+        private bool _success;
+        private Uri _uri = new Uri(TestConstants.Uris.HttpBin, "/post");
+
+        protected override void Given()
+        {
+            base.Given();
+            WebView.NavigationCompleted += (o, e) =>
+            {
+                _success = e.IsSuccess;
+                Form.Close();
+            };
+        }
+
+        protected override void When()
+        {
+
+            NavigateAndWaitForFormClose(
+                _uri,
+                HttpMethod.Post,
+                "{\"prop\":\"content\"}",
+                new []{new KeyValuePair<string, string>("accept", "application/json"), });
+        }
+
+        [TestMethod]
+        [Timeout(TestConstants.Timeouts.Longest)]
+        public void NavigationShouldComplete()
+        {
+            _success.ShouldBeTrue();
+        }
+    }
+}

--- a/Microsoft.Toolkit.Win32/Tests/UnitTests.WebView.WinForms/FunctionalTests/WebViewFormContextSpecification.cs
+++ b/Microsoft.Toolkit.Win32/Tests/UnitTests.WebView.WinForms/FunctionalTests/WebViewFormContextSpecification.cs
@@ -3,7 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
 using System.Windows.Forms;
 using Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT;
 using Should;
@@ -85,6 +89,41 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Test.WinForms.WebView.FunctionalTe
             {
                 WriteLine($"Navigating WebView with URI: {uri}");
                 WebView.Navigate(uri);
+            });
+        }
+
+        protected virtual void NavigateAndWaitForFormClose(
+            Uri requestUri,
+            HttpMethod httpMethod,
+            string content = null,
+            IEnumerable<KeyValuePair<string, string>> headers = null)
+        {
+            PerformActionAndWaitForFormClose(() =>
+            {
+                string Convert(IEnumerable<KeyValuePair<string, string>> kvp)
+                {
+                    if (kvp == null)
+                    {
+                        kvp = Enumerable.Empty<KeyValuePair<string, string>>();
+                    }
+
+                    var sb = new StringBuilder();
+                    foreach (var k in kvp)
+                    {
+                        sb.AppendLine($"\r\n    {k.Key}={k.Value}");
+                    }
+
+                    return sb.ToString();
+                }
+
+                WriteLine(
+@"Navigating WebView with
+  URI:     {0}
+  METHOD:  {1}
+  CONTENT: {2}
+  HEADERS: {3}",
+                    requestUri, httpMethod, content??string.Empty, Convert(headers));
+                WebView.Navigate(requestUri, httpMethod, content, headers);
             });
         }
 


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
- Other... Please describe: functional tests


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There are currently no tests to cover new `Navigate` methods that use `NavigateWithHttpMessage` in Win32 WebView.

## What is the new behavior?
Add navigation tests for HTTP GET and POST

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
