### PR TITLE
Add support for creating web views in the same WWAHost process

### DIFF
--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebView.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebView.cs
@@ -152,6 +152,13 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
             _initializationComplete = new ManualResetEvent(false);
         }
 
+        [SecurityCritical]
+        public WebView(WebViewControlProcess process)
+            : this()
+        {
+            _process = process;
+        }
+
         internal WebView(WebViewControlHost webViewControl)
             : this()
         {

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.Init.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.Init.cs
@@ -114,18 +114,30 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
 
                 if (!WebViewControlInitialized)
                 {
-                    Verify.IsNull(Process);
-
-                    // Was not injected via ctor, create using defaults
-                    var options = new Interop.WinRT.WebViewControlProcessOptions()
+                    if (Process == null)
                     {
-                        PrivateNetworkClientServerCapability = (Interop.WinRT.WebViewControlProcessCapabilityState)(_delayedPrivateNetworkEnabled
-                            ? WebViewControlProcessCapabilityState.Enabled
-                            : WebViewControlProcessCapabilityState.Disabled),
-                        EnterpriseId = _delayedEnterpriseId
-                    };
+                        // Was not injected via ctor, create using defaults
+                        var options = new Interop.WinRT.WebViewControlProcessOptions()
+                        {
+                            PrivateNetworkClientServerCapability =
+                                (Interop.WinRT.WebViewControlProcessCapabilityState)(_delayedPrivateNetworkEnabled
+                                    ? WebViewControlProcessCapabilityState.Enabled
+                                    : WebViewControlProcessCapabilityState.Disabled),
+                            EnterpriseId = _delayedEnterpriseId
+                        };
 
-                    Process = new WebViewControlProcess(options);
+                        Process = new WebViewControlProcess(options);
+                    }
+                    else
+                    {
+                        Verify.IsNotNull(Process);
+
+                        _delayedPrivateNetworkEnabled = Process.IsPrivateNetworkClientServerCapabilityEnabled;
+                        _delayedEnterpriseId = Process.EnterpriseId;
+                    }
+
+                    Verify.IsNotNull(Process);
+
                     _webViewControl = Process.CreateWebViewControlHost(Handle, ClientRectangle);
                     SubscribeEvents();
 

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.cs
@@ -55,6 +55,12 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
             Layout += OnWebViewLayout;
         }
 
+        public WebView(WebViewControlProcess process)
+            : this()
+        {
+            Process = process;
+        }
+
         internal WebViewControlHost Host => _webViewControl;
 
         /// <inheritdoc />

--- a/Microsoft.Toolkit.Win32/Tests/UnitTests.WebView.WinForms/FunctionalTests/Cookies/CookieTests.cs
+++ b/Microsoft.Toolkit.Win32/Tests/UnitTests.WebView.WinForms/FunctionalTests/Cookies/CookieTests.cs
@@ -1,0 +1,248 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT;
+using Microsoft.Toolkit.Win32.UI.Controls.Test.WebView.Shared;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Should;
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.Test.WinForms.WebView.FunctionalTests.Cookies
+{
+    [TestCategory(TestConstants.Categories.Nav)]
+    public abstract class CookieTestContext : HostFormWebViewContextSpecification
+    {
+        public Uri CookieUri { get; } = new Uri(TestConstants.Uris.HttpBin, "/cookies");
+
+        protected abstract Task SetCookieAsync(Controls.WinForms.WebView webView);
+
+        protected async Task SetCookieAsync(
+            Controls.WinForms.WebView webView,
+            string cookieName,
+            string cookieValue,
+            DateTime? expiry = null)
+        {
+            string formatExpiry(DateTime? e) => e != null
+                ? $"; expires={e.Value.ToUniversalTime():R}"
+                : string.Empty;
+
+            var cookie = $"{cookieName}={cookieValue}{formatExpiry(expiry)}";
+            if (webView != null)
+            {
+                await webView.InvokeScriptAsync("eval", $"document.cookie = \"{cookie}\"").ConfigureAwait(false);
+            }
+        }
+
+        protected Task<string> GetCookiesAsync(Controls.WinForms.WebView webView)
+        {
+            return webView.InvokeScriptAsync("eval", "document.cookie");
+        }
+
+        protected override void When()
+        {
+            NavigateAndWaitForFormClose(CookieUri);
+        }
+    }
+
+    public abstract class MultipleWebViewCookieTestContext : CookieTestContext
+    {
+        public Controls.WinForms.WebView SecondWebView { get; private set; }
+
+        public string Webview1Cookie
+        {
+            get => _webview1Cookie;
+            private set
+            {
+                WriteLine("WebView1 Cookie: {0}", value);
+                _webview1Cookie = value;
+            }
+        }
+
+        public string Webview2Cookie
+        {
+            get => _webview2Cookie;
+            private set
+            {
+                WriteLine("WebView2 Cookie: {0}", value);
+                _webview2Cookie = value;
+            }
+        }
+
+        private string _webview2Cookie;
+        private string _webview1Cookie;
+
+        protected override void Given()
+        {
+            base.Given();
+
+            WebView.NavigationCompleted += OnWebViewOnNavigationCompleted;
+        }
+
+        private async void OnWebViewOnNavigationCompleted(object sender, WebViewControlNavigationCompletedEventArgs e)
+        {
+            if (!e.IsSuccess)
+            {
+                Form.Close();
+            }
+
+            if (sender is Controls.WinForms.WebView wv)
+            {
+                if (SecondWebView == null)
+                {
+                    await SetCookieAsync(wv);
+                    Webview1Cookie = await GetCookiesAsync(wv);
+
+
+                    // Once the session cookie is set
+                    SecondWebView = CreateSecondWebView(wv.Process);
+                    SecondWebView.NavigationCompleted += OnWebViewOnNavigationCompleted;
+                    SecondWebView.Navigate(CookieUri);
+                }
+                else
+                {
+                    Webview2Cookie = await GetCookiesAsync(wv);
+                    Form.Close();
+                }
+            }
+        }
+
+        protected override void Cleanup()
+        {
+            SecondWebView?.Dispose();
+
+            base.Cleanup();
+        }
+
+        protected abstract Controls.WinForms.WebView CreateSecondWebView(WebViewControlProcess process);
+    }
+
+    public abstract class WebViewDifferentProcessContext : MultipleWebViewCookieTestContext
+    {
+        protected override Controls.WinForms.WebView CreateSecondWebView(WebViewControlProcess process)
+        {
+            var webView = new Controls.WinForms.WebView();
+            ((ISupportInitialize)webView).BeginInit();
+            webView.IsScriptNotifyAllowed = WebView.IsScriptNotifyAllowed;
+            webView.IsIndexedDBEnabled = WebView.IsIndexedDBEnabled;
+            webView.IsJavaScriptEnabled = WebView.IsJavaScriptEnabled;
+            ((ISupportInitialize)webView).EndInit();
+
+            return webView;
+        }
+    }
+
+    public abstract class WebViewSameProcessContext : MultipleWebViewCookieTestContext
+    {
+        protected override Controls.WinForms.WebView CreateSecondWebView(WebViewControlProcess process)
+        {
+            var webView = new Controls.WinForms.WebView(process);
+            ((ISupportInitialize) webView).BeginInit();
+            webView.IsScriptNotifyAllowed = WebView.IsScriptNotifyAllowed;
+            webView.IsIndexedDBEnabled = WebView.IsIndexedDBEnabled;
+            webView.IsJavaScriptEnabled = WebView.IsJavaScriptEnabled;
+            ((ISupportInitialize) webView).EndInit();
+
+            return webView;
+        }
+
+
+    }
+
+    [TestClass]
+    public class PersistentCookieSameProcessTests : WebViewSameProcessContext
+    {
+        [TestMethod]
+        [Timeout(TestConstants.Timeouts.Longest)]
+        public void PersistentCookieIsInNewWebView()
+        {
+            Webview1Cookie.ShouldNotBeNull();
+            Webview2Cookie.ShouldNotBeNull();
+
+            Webview2Cookie.ShouldEqual(Webview1Cookie);
+        }
+
+        protected override Task SetCookieAsync(Controls.WinForms.WebView webView)
+        {
+            return SetCookieAsync(webView, "persistent", "true", DateTime.UtcNow.Add(TimeSpan.FromSeconds(TestConstants.Timeouts.Longest)));
+        }
+
+        protected override void Cleanup()
+        {
+            // Best effort clean up. Initial cookie has a short TTL anyway
+            SetCookieAsync(SecondWebView, "persistent", string.Empty, new DateTime(1970, 1, 1));
+
+            base.Cleanup();
+        }
+    }
+
+    [TestClass]
+    public class PersistentCookieDifferentProcessTests : WebViewDifferentProcessContext
+    {
+        [TestMethod]
+        [Timeout(TestConstants.Timeouts.Longest)]
+        public void PersistentCookieIsInNewWebView()
+        {
+            Webview1Cookie.ShouldNotBeNull();
+            Webview2Cookie.ShouldNotBeNull();
+
+            Webview2Cookie.ShouldEqual(Webview1Cookie);
+        }
+
+        protected override Task SetCookieAsync(Controls.WinForms.WebView webView)
+        {
+            return SetCookieAsync(webView, "persistent", "true", DateTime.UtcNow.Add(TimeSpan.FromSeconds(TestConstants.Timeouts.Longest)));
+        }
+
+        protected override void Cleanup()
+        {
+            // Best effort clean up. Initial cookie has a short TTL anyway
+            SetCookieAsync(SecondWebView, "persistent", string.Empty, new DateTime(1970, 1, 1));
+
+            base.Cleanup();
+        }
+    }
+
+    [TestClass]
+    public class SessionCookieSameProcessTests : WebViewSameProcessContext
+    {
+        [TestMethod]
+        [Timeout(TestConstants.Timeouts.Longest)]
+        public void SessionCookieIsInNewWebView()
+        {
+            Webview1Cookie.ShouldNotBeNull();
+            Webview2Cookie.ShouldNotBeNull();
+
+            Webview2Cookie.ShouldEqual(Webview1Cookie);
+        }
+
+        protected override Task SetCookieAsync(Controls.WinForms.WebView webView)
+        {
+            return SetCookieAsync(webView, "session", "true");
+        }
+    }
+
+    [TestClass]
+    public class SessionCookieDifferentProcessTests : WebViewDifferentProcessContext
+    {
+        [TestMethod]
+        [Timeout(TestConstants.Timeouts.Longest)]
+        public void SessionCookieIsNotInNewWebView()
+        {
+            Webview1Cookie.ShouldNotBeNull();
+            Webview2Cookie.ShouldNotBeNull();
+
+            Webview2Cookie.ShouldNotEqual(Webview1Cookie);
+        }
+
+        protected override Task SetCookieAsync(Controls.WinForms.WebView webView)
+        {
+            return SetCookieAsync(webView, "session", "true");
+        }
+    }
+}

--- a/docs/controls/WebView-known-issues.md
+++ b/docs/controls/WebView-known-issues.md
@@ -60,7 +60,7 @@ The **WebView** control implements these events of the [IWebViewControl](https:/
 
 * Content in the **WebView** can be blocked even if the user responds to a system prompt by providing permission to the control.
 
-  This can happen if the Win32WebViewHost (or "Desktop Web App Viewer" in Insider builds) application is disabled in the location settings of the user's system. Users can open those settings and enable the Win32WebViewHost (or "Desktop Web App Viewer" in Insider builds) application to resolve the issue.
+  This can happen if the Win32WebViewHost (or "Desktop Web App Viewer" in Insider builds) application is disabled in the location settings of the user's system. To resolve the issue, users can open those settings and enable the Win32WebViewHost (or "Desktop Web App Viewer" in Insider builds) application.
 
 * **WebView** controls won't function as expected in a WPF-based ClickOnce application.
 
@@ -82,7 +82,7 @@ The **WebView** control implements these events of the [IWebViewControl](https:/
 
 * **WebView** controls don't recognize the ms-appx:/// prefix, so they can't read from the package (if you've created a package for your application).
 
-* **WebView** controls don't recognize the File:// prefix. If you want to read a file into a **WebView** control, use the `NavigateToLocal(String)` or the `NavigateToLocalStreamUri(Uri, IUriToStreamResolver)`, or add code to your application that reads the content of the file. Then, serialize that content into a string, and call the `NavigateToString(String)` method of the **WebView** control.
+* **WebView** controls don't recognize the File:// prefix. If you want to read a file into a **WebView** control, call the `NavigateToLocal(String)` or the `NavigateToLocalStreamUri(Uri, IUriToStreamResolver)` method, or add code to your application that reads the content of the file. Then, serialize that content into a string, and call the `NavigateToString(String)` method of the **WebView** control.
 
 * **WebView** controls don't support URI's that are not encoded in UTF-8. Characters between UTF-16 and UTF-32 aren't supported.
 

--- a/docs/controls/WebView-known-issues.md
+++ b/docs/controls/WebView-known-issues.md
@@ -50,7 +50,7 @@ The **WebView** control implements these events of the [IWebViewControl](https:/
 
 * **WebView** controls in WPF applications have longer load times than Windows Forms applications.
 
-* If the web view stops responding or stops working, other applications that use the same underlying process (Win32WebViewHost) will stop responding or stop working as well.
+* If the web view stops responding or stops working, other applications that use the same underlying process (WWAHost) will stop responding or stop working as well.
 
 ## Security
 
@@ -60,7 +60,7 @@ The **WebView** control implements these events of the [IWebViewControl](https:/
 
 * Content in the **WebView** can be blocked even if the user responds to a system prompt by providing permission to the control.
 
-  This can happen if the Win32WebViewHost application is disabled in the location settings of the user's system. Users can open those settings and enable the Win32WebViewHost application to resolve the issue.
+  This can happen if the Win32WebViewHost (or "Desktop Web App Viewer" in Insider builds) application is disabled in the location settings of the user's system. Users can open those settings and enable the Win32WebViewHost (or "Desktop Web App Viewer" in Insider builds) application to resolve the issue.
 
 * **WebView** controls won't function as expected in a WPF-based ClickOnce application.
 
@@ -82,7 +82,7 @@ The **WebView** control implements these events of the [IWebViewControl](https:/
 
 * **WebView** controls don't recognize the ms-appx:/// prefix, so they can't read from the package (if you've created a package for your application).
 
-* **WebView** controls don't recognize the File:// prefix. If you want to read a file into a **WebView** control, add code to your application that reads the content of the file. Then, serialize that content into a string, and call the ``NavigateToString(String)`` method of the **WebView** control.
+* **WebView** controls don't recognize the File:// prefix. If you want to read a file into a **WebView** control, use the `NavigateToLocal(String)` or the `NavigateToLocalStreamUri(Uri, IUriToStreamResolver)`, or add code to your application that reads the content of the file. Then, serialize that content into a string, and call the `NavigateToString(String)` method of the **WebView** control.
 
 * **WebView** controls don't support URI's that are not encoded in UTF-8. Characters between UTF-16 and UTF-32 aren't supported.
 
@@ -96,8 +96,6 @@ The **WebView** control implements these events of the [IWebViewControl](https:/
 
 * Service workers can't run in a **WebView** control.
 
-* Your code can't instantiate more than one instance of a **WebView** in the same Win32WebViewHost process.
-
 ## WebView browser
 
 * The [WebBrower.ObjectForScripting](https://msdn.microsoft.com/library/system.windows.controls.webbrowser.objectforscripting.aspx) property and [WebView.AddWebAllowedObject(String, Object)](https://docs.microsoft.com/uwp/api/windows.ui.xaml.controls.webview.addweballowedobject) are not supported.
@@ -107,10 +105,6 @@ The **WebView** control implements these events of the [IWebViewControl](https:/
 * You can't programmatically navigate by using a new window.
 
 * You can't programmatically navigate to a specific frame.
-
-* You can't programmatically navigate to a relative URI.
-
-  To work around this issue, consider reading from a stream into a string, and then calling the NavigateToString(String) method of the WebView control.
 
 * You can't programmatically print information from a WebView control.
 

--- a/docs/controls/WebView.md
+++ b/docs/controls/WebView.md
@@ -307,9 +307,14 @@ Scripts in the web view content can use **window.external.notify** with a string
 You can use the [Settings](https://docs.microsoft.com/uwp/api/windows.web.ui.interop.webviewcontrol.settings) property (of type [WebViewControlSettings](https://docs.microsoft.com/uwp/api/windows.web.ui.interop.webviewcontrolsettings) to control whether JavaScript and IndexedDB are enabled. For example, if you use a web view to display strictly static content, you might want to disable JavaScript for best performance.
 
 ## Creating multiple web views in the same process
-By default **WebView** is hosted outside of your application's process in WWAHost. Using the designer or default constructor, each new **WebView** is created in a new WWAHost instance. To share session cookies and state, consider using the same WWAHost process to host your **WebView**.
 
-For example, if using Windows Forms and through the designer a web view named `webView1` is on `Form1`, you can create a new **WebView** that shares the same process and state with `webView1` like this.
+By default, the **WebView** is hosted outside of your application's process in a process called WWAHost. When using the designer or default constructor, each new **WebView** is created in a new WWAHost instance, with its own copy of state. To share session cookies and state, consider using the same WWAHost process to host your **WebView**.
+
+### For Windows Forms Applications
+
+For example, if through the designer a **WebView** named `webView1` is on `Form1`, you can create a new **WebView** that shares the same process and state with `webView1` like this.
+
+**Form1.cs**
 ```csharp
 public partial class Form1 : Form
 {
@@ -319,36 +324,48 @@ public partial class Form1 : Form
     {
         InitializeComponent();
 
+        // Assume webView created through the designer
         webView2 = new WebView(webView1.Process);
         ((ISupportInitialize)webView).BeginInit();
         // ... other initialization code
-        ((ISupportInitialize)webView).EndInit();        
+        ((ISupportInitialize)webView).EndInit();
     }
 }
 ```
 
+### For WPF Applications
+
+Similar to the Windows Forms example, if through the designer a **WebView** is created named `WebView1` on the `Window`, you can create a new **WebView** that shares the same process and state with `WebView1` like this.
+
 **MainWindow.xaml**
+
 ```xaml
 <Window
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:WPF="clr-namespace:Microsoft.Toolkit.Win32.UI.Controls.WPF;assembly=Microsoft.Toolkit.Win32.UI.Controls"
     Title="MainWindow"
     Width="800"
     Height="450"
-    Loaded="Window_Loaded"
     mc:Ignorable="d">
     <Grid x:Name="Grid1" Grid.Row="1">
         <Grid.ColumnDefinitions>
             <ColumnDefinition />
             <ColumnDefinition />
         </Grid.ColumnDefinitions>
+
+         <WPF:WebView x:Name="WebView1"
+                      Grid.Row="0"
+                      Grid.Column="0"
+                      Loaded="WebView_Loaded" />
     </Grid>
 </Window>
 ```
 
 **MainWindow.xaml.cs**
+
 ```csharp
 public partial class MainWindow : Window
 {
@@ -357,23 +374,14 @@ public partial class MainWindow : Window
         InitializeComponent();
     }
 
-    private async void Window_Loaded(object sender, RoutedEventArgs e)
+    private void WebView_Loaded(object sender, RoutedEventArgs e)
     {
-        var webView = new WebView();
-        webView.BeginInit();
-        webView.EndInit();
-
-        Grid.SetRow(webView, 0);
-        Grid.SetColumn(webView, 0);
-
-        Grid1.Children.Add(webView);
-
-        var webView2 = new WebView(webView1.Process);
+        var webView2 = new WebView(WebView1.Process);
         webView2.BeginInit();
         webView2.EndInit();
 
         Grid.SetRow(webView2, 0);
-        Grid.SetColumn(webView2, 0);
+        Grid.SetColumn(webView2, 1);
 
         Grid1.Children.Add(webView2);
     }

--- a/docs/controls/WebView.md
+++ b/docs/controls/WebView.md
@@ -306,6 +306,80 @@ Scripts in the web view content can use **window.external.notify** with a string
 
 You can use the [Settings](https://docs.microsoft.com/uwp/api/windows.web.ui.interop.webviewcontrol.settings) property (of type [WebViewControlSettings](https://docs.microsoft.com/uwp/api/windows.web.ui.interop.webviewcontrolsettings) to control whether JavaScript and IndexedDB are enabled. For example, if you use a web view to display strictly static content, you might want to disable JavaScript for best performance.
 
+## Creating multiple web views in the same process
+By default **WebView** is hosted outside of your application's process in WWAHost. Using the designer or default constructor, each new **WebView** is created in a new WWAHost instance. To share session cookies and state, consider using the same WWAHost process to host your **WebView**.
+
+For example, if using Windows Forms and through the designer a web view named `webView1` is on `Form1`, you can create a new **WebView** that shares the same process and state with `webView1` like this.
+```csharp
+public partial class Form1 : Form
+{
+    private WebView webView2;
+
+    public Form1()
+    {
+        InitializeComponent();
+
+        webView2 = new WebView(webView1.Process);
+        ((ISupportInitialize)webView).BeginInit();
+        // ... other initialization code
+        ((ISupportInitialize)webView).EndInit();        
+    }
+}
+```
+
+**MainWindow.xaml**
+```xaml
+<Window
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Title="MainWindow"
+    Width="800"
+    Height="450"
+    Loaded="Window_Loaded"
+    mc:Ignorable="d">
+    <Grid x:Name="Grid1" Grid.Row="1">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition />
+            <ColumnDefinition />
+        </Grid.ColumnDefinitions>
+    </Grid>
+</Window>
+```
+
+**MainWindow.xaml.cs**
+```csharp
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+
+    private async void Window_Loaded(object sender, RoutedEventArgs e)
+    {
+        var webView = new WebView();
+        webView.BeginInit();
+        webView.EndInit();
+
+        Grid.SetRow(webView, 0);
+        Grid.SetColumn(webView, 0);
+
+        Grid1.Children.Add(webView);
+
+        var webView2 = new WebView(webView1.Process);
+        webView2.BeginInit();
+        webView2.EndInit();
+
+        Grid.SetRow(webView2, 0);
+        Grid.SetColumn(webView2, 0);
+
+        Grid1.Children.Add(webView2);
+    }
+}
+```
+
 ## Requirements
 
 | Device family | .NET 4.6.2, Windows 10 (introduced v10.0.17110.0) |


### PR DESCRIPTION
Issue: #2375
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
With the traditional API, invoking `new WebView()` would always create a web view in a new WWAHost and Win32WebViewHost process. In some cases, state needs to be shared between individual views, such as for single sign on scenarios, to avoid having each web view authenticate.  Edge does not persist session state to disk to both maintain performance and provide a safe way to remove session state in the event of a crash. When a new web view process is created, Edge internally copies all the session state it can to the new process. With the default .ctor each web view was created in its own WWAHost process, and each was treated as a new session, failing to inherit any of the ephemeral session state. However, any state that was persisted to disk, such as cookies with a future expiration, would be read into the new web view session.

## What is the new behavior?
The new API permits passing in a `WebViewControlProcess` via .ctor overload that will be used to create the process. An instance of `WebViewControlProcess` can be obtained by calling `new WebViewControlProcess()` or by using the `WebView.Process` property of an existing web view. Tests have also been added to ensure cookie behavior is maintained between web views in the same process, and thus the same session, but not web views that are in different processes (and thus in different sessions).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
CC @purani
Resolves #2375