### PR TITLE
Remove UI hang for some WPF WebView properties and methods

### DIFF
--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/DispatcherExtensions.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/DispatcherExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Windows.Threading;
 
 namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
@@ -15,10 +16,12 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         /// Pushes an empty <see cref="DispatcherFrame"/> at <see cref="DispatcherPriority.ContextIdle"/>.
         /// </summary>
         /// <param name="dispatcher">A <see cref="Dispatcher"/> instance.</param>
+        /// <param name="priority">The <see cref="DispatcherPriority"/> of the idle frame.</param>
         /// <remarks>
         /// No frame is pushed if the <paramref name="dispatcher"/> is null, <see cref="Dispatcher.HasShutdownStarted"/> is true, or <see cref="Dispatcher.HasShutdownFinished"/> is true.
         /// </remarks>
-        internal static void DoEvents(this Dispatcher dispatcher)
+        [DebuggerStepThrough]
+        internal static void DoEvents(this Dispatcher dispatcher, DispatcherPriority priority = DispatcherPriority.ContextIdle)
         {
             object ExitFrame(object arg)
             {
@@ -34,7 +37,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
                 // Set the priority to ContextIdle to force the queue to flush higher priority events
                 var frame = new DispatcherFrame();
                 dispatcher.BeginInvoke(
-                    DispatcherPriority.ContextIdle,
+                    priority,
                     new DispatcherOperationCallback(ExitFrame),
                     frame);
                 Dispatcher.PushFrame(frame);

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebView.Dispatch.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebView.Dispatch.cs
@@ -1,0 +1,120 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
+{
+    /// <summary>
+    /// Contains dispatcher code
+    /// </summary>
+    public sealed partial class WebView
+    {
+        private const int InitializationBlockingTime = 200;
+
+        /// <summary>
+        /// Dispatches a blank frame to allow dispatcher queue to flush. If WebViewControl is not initialized, waits for control
+        /// to be loaded by subscribing to Loaded event. Once loaded finishes blocking until control is initialized, then
+        /// dispatches a message to perform the <paramref name="callback"/>
+        /// </summary>
+        /// <param name="callback">The callback to perform after loaded</param>
+        /// <remarks>
+        /// This exists to
+        /// </remarks>
+        private void InvokeAfterInitializing(Action callback)
+        {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+
+            // Fast path: if the control is already initialized call the callback directly
+            if (WebViewControlInitialized)
+            {
+                callback();
+            }
+
+            // Slower path: control is already loaded, but web view is not initialized
+            else if (IsLoaded)
+            {
+                // Block until the web view initialization is completed on the dispatcher
+                InvokeAfterInitializing();
+                callback();
+            }
+
+            // Slow path: wait for Loaded event and re-enter
+            else
+            {
+                void OnLoaded(object o, RoutedEventArgs e)
+                {
+                    // This fires early in the cycle.
+                    // Unwire the event
+                    Loaded -= OnLoaded;
+
+                    // And re-enter the method. IsLoaded will be true
+                    InvokeAfterInitializing(callback);
+                }
+
+                // Wait for Loaded event to fire, meaning WPF has created most of what is needed for HwndHost to proceed
+                Loaded += OnLoaded;
+            }
+        }
+
+        /// <summary>
+        /// Dispatches a blank frame to allow dispatcher queue to flush. If WebViewControl is not initialized, waits for control
+        /// to be loaded by subscribing to Loaded event. Once loaded finishes blocking until control is initialized, then
+        /// dispatches a message to perform the <paramref name="callback"/>
+        /// </summary>
+        /// <param name="callback">The callback to perform after loaded</param>
+        /// <remarks>
+        /// This exists to
+        /// </remarks>
+        /// <typeparam name="T">The type of the return value.</typeparam>
+        /// <returns>The result of <paramref name="callback"/></returns>
+        /// <exception cref="InvalidOperationException">Occurs when the callback cannot be completed because the control is not yet loaded.</exception>
+        private T InvokeAfterInitializing<T>(Func<T> callback)
+        {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+
+            // Fast path: if the control is already initialized call the callback directly
+            if (WebViewControlInitialized)
+            {
+                return callback();
+            }
+
+            // Slightly slower path: control is already loaded, but web view not initialized
+            if (IsLoaded)
+            {
+                // Block until the web view initialization is completed on the dispatcher
+                InvokeAfterInitializing();
+                return callback();
+            }
+
+            // Not possible: we would need to wait for loaded event
+            // but may be called early enough in the lifetime where the dispatcher thread is the UI thread
+            // such as after InitializeComponents in MainWindow
+            throw new InvalidOperationException(DesignerUI.E_WEBVIEW_CANNOT_INVOKE_BEFORE_INIT);
+        }
+
+        /// <summary>
+        /// Dispatches empty frames to Dispatcher queue while web view is initializing to keep UI responsive
+        /// </summary>
+        /// <seealso cref="DispatcherExtensions.DoEvents"/>
+        [DebuggerStepThrough]
+        private void InvokeAfterInitializing(DispatcherPriority priority = DispatcherPriority.ContextIdle)
+        {
+            do
+            {
+                Dispatcher.CurrentDispatcher.DoEvents(priority);
+            }
+            while (!_initializationComplete.WaitOne(InitializationBlockingTime));
+        }
+    }
+}


### PR DESCRIPTION
Issue: #2374
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If a caller invokes a property or method that requires the web view to be initialized, it is common to have code to push empty frames onto the dispatcher queue until the web view initialization completed. However, depending on where the caller's code invoke the web view property or method, initialization may never occur and the control continues to dispatch empty frames to the queue.

This change modifies the initialization wait behavior for the following items:
- Properties
  - IsVisible
  - Process
- Methods
  - AddPreLoadedScript
  - GetDeferredPermissionRequestById
  - GoBack
  - GoForward
  - InvokeScript
  - InvokeScriptAsync
  - MoveFocus
  - Navigate
  - NavigateToLocal
  - NavigateToLocalStreamUri
  - NavigateToString
  - Refresh
  - Stop

Current behavior
- IsVisible. When invoking the getter a NullReferenceException may be thrown if the underlying web view control is not initialized.
- Process. Getter is blocked until initialization is completed.
- AddPreLoadedScript. If underlying web view control is not initialized do nothing.
- GetDeferredPermissionRequestById. Same as above.
- GoBack/GoForward. If underlying web view control is not initialized, perform no action and return FALSE.
- InvokeScript/InvokeScriptAsync. Methods are blocked until initialization is completed.
- MoveFocus. If underlying web view control is not initialized do nothing.
- Navigate/NavigateToLocal/NavigateToLocalStreamUri/NavigateToString. Method is blocked until web view is initialized.
- Refresh. If underlying web view control is not initialized do nothing.
- Stop. Same as above.

## What is the new behavior?
- IsVisible. When invoking the getter, if the underlying web view control is not initialized FALSE is returned.
- Process. Getter returns NULL if the underlying web view control is not initialized.
- AddPreLoadedScript. If control is not yet loaded, wait for Loaded event to fire; if control is loaded but underlying web view control is not initialized, wait for web view initialization; if Loaded and web view is initialized, invoke the callback.
- GetDeferredPermissionRequestById. Same as above.
- GoBack/GoForward. If control is not yet loaded, throw; otherwise, if control is loaded but underlying web view control is not initialized, wait for web view initialization; if Loaded and web view is initialized, invoke the callback.
- InvokeScript/InvokeScriptAsync. Same as above.
- MoveFocus. If control is not yet loaded, wait for Loaded event to fire; if control is loaded but underlying web view control is not initialized, wait for web view initialization; if Loaded and web view is initialized, invoke the callback.
- Navigate/NavigateToLocal/NavigateToLocalStreamUri/NavigateToString. Same as above.
- Refresh. Same as above.
- Stop. Same as above.



## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
CC @purani
Resolves #2374