### PR TITLE
Change GridSplitter color when pressed.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.xaml
@@ -26,7 +26,7 @@
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SystemControlBackgroundBaseHighBrush}" />
+                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SystemControlBackgroundBaseMediumHighBrush}" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>


### PR DESCRIPTION
Change color from *BaseHigh* to *BaseMediumHigh* when in pressed state.
Closes #2380.

## PR Type
- Bugfix

## What is the current behavior?
GridSplitter goes completely white when pressed in Dark Theme

## What is the new behavior?
When pressed color is now light grey in Dark Theme and dark grey in Light Theme

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
