### PR TITLE
Fix Expander, Menu, and InAppNotification background colors not switching while app is running.

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Expander/ExpanderXaml.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Expander/ExpanderXaml.bind
@@ -7,7 +7,7 @@
     mc:Ignorable="d">
 
   <Page.Resources>
-    <SolidColorBrush Color="{StaticResource SystemChromeLowColor}" x:Key="SystemControlForegroundChromeLowBrush"/>
+    <SolidColorBrush Color="{ThemeResource SystemChromeLowColor}" x:Key="SystemControlForegroundChromeLowBrush"/>
   </Page.Resources>
 
   <Grid>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
@@ -1,14 +1,12 @@
-﻿<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-    xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
-    mc:Ignorable="d">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    mc:Ignorable="d">
 
-    <SolidColorBrush Color="{StaticResource SystemChromeLowColor}" x:Key="SystemControlBackgroundChromeLowBrush" />
-
-    <Style x:Key="HeaderToggleButtonStyle" TargetType="ToggleButton">
+    <Style x:Key="HeaderToggleButtonStyle"
+           TargetType="ToggleButton">
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}" />
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundTransparentBrush}" />
@@ -25,122 +23,181 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToggleButton">
-                    <Grid x:Name="RootGrid" Background="{TemplateBinding Background}">
+                    <Grid x:Name="RootGrid"
+                          Background="{TemplateBinding Background}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <Slider x:Name="ArrowRotation"
+                                Maximum="180"
+                                Minimum="-180"
+                                Visibility="Collapsed"
+                                Value="90" />
+
+                        <FontIcon x:Name="Arrow"
+                                  Margin="12"
+                                  FontFamily="Segoe MDL2 Assets"
+                                  FontSize="12"
+                                  Glyph="&#xE76C;"
+                                  RenderTransformOrigin="0.5,0.5">
+                            <FontIcon.RenderTransform>
+                                <RotateTransform />
+                            </FontIcon.RenderTransform>
+                        </FontIcon>
+
+                        <ContentPresenter x:Name="ContentPresenter"
+                                          Grid.Column="1"
+                                          Margin="0,0,12,0"
+                                          Padding="{TemplateBinding Padding}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          AutomationProperties.AccessibilityView="Raw"
+                                          BorderBrush="{TemplateBinding BorderBrush}"
+                                          BorderThickness="{TemplateBinding BorderThickness}"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          ContentTransitions="{TemplateBinding ContentTransitions}"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          RenderTransformOrigin="0.5,0.5" />
+
+                        <Rectangle x:Name="HoverPanel"
+                                   Grid.ColumnSpan="2"
+                                   Fill="Transparent" />
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal">
                                     <Storyboard>
                                         <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
-                                        <DoubleAnimation BeginTime="0:0:0" Duration="0:0:0.1" To="0.0"
+                                        <DoubleAnimation BeginTime="0:0:0"
+                                                         Storyboard.TargetName="Arrow"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(RotateTransform.Angle)"
-                                                         Storyboard.TargetName="Arrow" />
+                                                         To="0.0"
+                                                         Duration="0:0:0.1" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="PointerOver">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill"
-                                                                       Storyboard.TargetName="HoverPanel">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HoverPanel"
+                                                                       Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlBackgroundListLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
 
                                         <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
-                                        <DoubleAnimation BeginTime="0:0:0" Duration="0:0:0.1" To="0.0"
+                                        <DoubleAnimation BeginTime="0:0:0"
+                                                         Storyboard.TargetName="Arrow"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(RotateTransform.Angle)"
-                                                         Storyboard.TargetName="Arrow" />
+                                                         To="0.0"
+                                                         Duration="0:0:0.1" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill"
-                                                                       Storyboard.TargetName="HoverPanel">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HoverPanel"
+                                                                       Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlBackgroundListMediumBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
 
-                                        <DoubleAnimation BeginTime="0:0:0" Duration="0:0:0.1" To="0.0"
+                                        <DoubleAnimation BeginTime="0:0:0"
+                                                         Storyboard.TargetName="Arrow"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(RotateTransform.Angle)"
-                                                         Storyboard.TargetName="Arrow" />
+                                                         To="0.0"
+                                                         Duration="0:0:0.1" />
                                         <PointerDownThemeAnimation Storyboard.TargetName="RootGrid" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Disabled">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill"
-                                                                       Storyboard.TargetName="HoverPanel">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HoverPanel"
+                                                                       Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
 
-                                        <DoubleAnimation BeginTime="0:0:0" Duration="0:0:0.1" To="0.0"
+                                        <DoubleAnimation BeginTime="0:0:0"
+                                                         Storyboard.TargetName="Arrow"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(RotateTransform.Angle)"
-                                                         Storyboard.TargetName="Arrow" />
+                                                         To="0.0"
+                                                         Duration="0:0:0.1" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Checked">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill"
-                                                                       Storyboard.TargetName="HoverPanel">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HoverPanel"
+                                                                       Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlHighlightListAccentLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
 
                                         <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
-                                        <DoubleAnimation BeginTime="0:0:0" Duration="0:0:0.1" To="{Binding ElementName=ArrowRotation, Path=Value}"
+                                        <DoubleAnimation BeginTime="0:0:0"
+                                                         Storyboard.TargetName="Arrow"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(RotateTransform.Angle)"
-                                                         Storyboard.TargetName="Arrow" />
+                                                         To="{Binding ElementName=ArrowRotation, Path=Value}"
+                                                         Duration="0:0:0.1" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="CheckedPointerOver">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill"
-                                                                       Storyboard.TargetName="HoverPanel">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HoverPanel"
+                                                                       Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlHighlightListAccentMediumBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
 
                                         <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
-                                        <DoubleAnimation BeginTime="0:0:0" Duration="0:0:0.1" To="{Binding ElementName=ArrowRotation, Path=Value}"
+                                        <DoubleAnimation BeginTime="0:0:0"
+                                                         Storyboard.TargetName="Arrow"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(RotateTransform.Angle)"
-                                                         Storyboard.TargetName="Arrow" />
+                                                         To="{Binding ElementName=ArrowRotation, Path=Value}"
+                                                         Duration="0:0:0.1" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="CheckedPressed">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill"
-                                                                       Storyboard.TargetName="HoverPanel">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HoverPanel"
+                                                                       Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlHighlightListAccentHighBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
 
-                                        <DoubleAnimation BeginTime="0:0:0" Duration="0:0:0.1" To="{Binding ElementName=ArrowRotation, Path=Value}"
+                                        <DoubleAnimation BeginTime="0:0:0"
+                                                         Storyboard.TargetName="Arrow"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(RotateTransform.Angle)"
-                                                         Storyboard.TargetName="Arrow" />
+                                                         To="{Binding ElementName=ArrowRotation, Path=Value}"
+                                                         Duration="0:0:0.1" />
                                         <PointerDownThemeAnimation Storyboard.TargetName="RootGrid" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="CheckedDisabled">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill"
-                                                                       Storyboard.TargetName="HoverPanel">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HoverPanel"
+                                                                       Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
 
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
-                                                                       Storyboard.TargetName="Arrow">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow"
+                                                                       Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlDisabledBaseLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
-                                                                       Storyboard.TargetName="ContentPresenter">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+                                                                       Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlDisabledBaseLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
 
-                                        <DoubleAnimation BeginTime="0:0:0" Duration="0:0:0.1" To="{Binding ElementName=ArrowRotation, Path=Value}"
+                                        <DoubleAnimation BeginTime="0:0:0"
+                                                         Storyboard.TargetName="Arrow"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(RotateTransform.Angle)"
-                                                         Storyboard.TargetName="Arrow" />
+                                                         To="{Binding ElementName=ArrowRotation, Path=Value}"
+                                                         Duration="0:0:0.1" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Indeterminate">
@@ -150,19 +207,19 @@
                                 </VisualState>
                                 <VisualState x:Name="IndeterminatePointerOver">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill"
-                                                                       Storyboard.TargetName="HoverPanel">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HoverPanel"
+                                                                       Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
 
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
-                                                                       Storyboard.TargetName="Arrow">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow"
+                                                                       Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
-                                                                       Storyboard.TargetName="ContentPresenter">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+                                                                       Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -172,19 +229,19 @@
                                 </VisualState>
                                 <VisualState x:Name="IndeterminatePressed">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill"
-                                                                       Storyboard.TargetName="HoverPanel">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HoverPanel"
+                                                                       Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlBackgroundBaseMediumLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
 
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
-                                                                       Storyboard.TargetName="Arrow">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow"
+                                                                       Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
-                                                                       Storyboard.TargetName="ContentPresenter">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+                                                                       Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -194,19 +251,19 @@
                                 </VisualState>
                                 <VisualState x:Name="IndeterminateDisabled">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill"
-                                                                       Storyboard.TargetName="HoverPanel">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HoverPanel"
+                                                                       Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
 
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
-                                                                       Storyboard.TargetName="Arrow">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow"
+                                                                       Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlDisabledBaseLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
-                                                                       Storyboard.TargetName="ContentPresenter">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+                                                                       Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlDisabledBaseLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -232,43 +289,6 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-
-                        <Slider x:Name="ArrowRotation" Visibility="Collapsed" Value="90" Minimum="-180" Maximum="180" />
-
-                        <FontIcon x:Name="Arrow"
-                                  FontFamily="Segoe MDL2 Assets"
-                                  FontSize="12"
-                                  Glyph="&#xE76C;"
-                                  RenderTransformOrigin="0.5,0.5"
-                                  Margin="12">
-                            <FontIcon.RenderTransform>
-                                <RotateTransform />
-                            </FontIcon.RenderTransform>
-                        </FontIcon>
-
-                        <ContentPresenter Grid.Column="1"
-                                          x:Name="ContentPresenter" 
-                                          AutomationProperties.AccessibilityView="Raw"
-                                          BorderBrush="{TemplateBinding BorderBrush}"
-                                          BorderThickness="{TemplateBinding BorderThickness}"
-                                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                                          ContentTransitions="{TemplateBinding ContentTransitions}"
-                                          Content="{TemplateBinding Content}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          Padding="{TemplateBinding Padding}"
-                                          VerticalAlignment="{TemplateBinding VerticalAlignment}"
-                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          RenderTransformOrigin="0.5,0.5"
-                                          Foreground="{TemplateBinding Foreground}"
-                                          Margin="0,0,12,0"/>
-
-                        <Rectangle x:Name="HoverPanel" Fill="Transparent" Grid.ColumnSpan="2"/>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
@@ -279,11 +299,81 @@
         <Setter Property="Header" Value="Header" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="HeaderStyle" Value="{StaticResource HeaderToggleButtonStyle}" />
-        <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeLowBrush}" />
+        <Setter Property="Background" Value="{ThemeResource SystemControlPageBackgroundChromeLowBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:Expander">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" >
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                        <Grid x:Name="PART_RootGrid"
+                              Background="{TemplateBinding Background}">
+                            <Grid.RowDefinitions>
+                                <RowDefinition x:Name="RowOne"
+                                               Height="Auto" />
+                                <RowDefinition x:Name="RowTwo"
+                                               Height="*" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition x:Name="ColumnOne"
+                                                  Width="Auto" />
+                                <ColumnDefinition x:Name="ColumnTwo"
+                                                  Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <ContentControl x:Name="PART_ContentOverlay"
+                                            Grid.Row="1"
+                                            Grid.RowSpan="1"
+                                            Grid.Column="0"
+                                            Grid.ColumnSpan="2"
+                                            HorizontalAlignment="Stretch"
+                                            VerticalAlignment="Stretch"
+                                            HorizontalContentAlignment="Stretch"
+                                            VerticalContentAlignment="Stretch"
+                                            Content="{TemplateBinding ContentOverlay}">
+                                <ContentControl.RenderTransform>
+                                    <ScaleTransform />
+                                </ContentControl.RenderTransform>
+                            </ContentControl>
+                            <Grid x:Name="PART_MainContent"
+                                  Grid.Row="1"
+                                  Grid.RowSpan="1"
+                                  Grid.Column="0"
+                                  Grid.ColumnSpan="2"
+                                  Background="{TemplateBinding Background}">
+                                <ContentPresenter x:Name="ContentPresenter"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  HorizontalContentAlignment="Stretch"
+                                                  VerticalContentAlignment="Stretch"
+                                                  Opacity="0">
+                                    <ContentPresenter.RenderTransform>
+                                        <TranslateTransform Y="20" />
+                                    </ContentPresenter.RenderTransform>
+                                </ContentPresenter>
+                                <Grid.RenderTransform>
+                                    <ScaleTransform />
+                                </Grid.RenderTransform>
+                            </Grid>
+                            <controls:LayoutTransformControl x:Name="PART_LayoutTransformer"
+                                                             Grid.Row="0"
+                                                             Grid.RowSpan="1"
+                                                             Grid.Column="0"
+                                                             Grid.ColumnSpan="2"
+                                                             RenderTransformOrigin="0.5,0.5">
+                                <controls:LayoutTransformControl.Transform>
+                                    <RotateTransform x:Name="RotateLayoutTransform" Angle="0" />
+                                </controls:LayoutTransformControl.Transform>
+                                <ToggleButton x:Name="PART_ExpanderToggleButton"
+                                              MinWidth="40"
+                                              MinHeight="40"
+                                              AutomationProperties.Name="Expand"
+                                              Content="{TemplateBinding Header}"
+                                              ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                              Foreground="{TemplateBinding Foreground}"
+                                              IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                              Style="{TemplateBinding HeaderStyle}"
+                                              TabIndex="0" />
+                            </controls:LayoutTransformControl>
+                        </Grid>
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="DisplayModeAndDirectionStates">
                                 <VisualState x:Name="VisibleLeft">
@@ -307,45 +397,63 @@
                                     </VisualState.Setters>
                                     <Storyboard>
                                         <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                         Storyboard.TargetProperty="(UIElement.Opacity)">
-                                            <LinearDoubleKeyFrame KeyTime="0" Value="0" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15" Value="0" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25" Value="1" />
+                                                                       Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <LinearDoubleKeyFrame KeyTime="0"
+                                                                  Value="0" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15"
+                                                                  Value="0" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25"
+                                                                  Value="1" />
                                         </DoubleAnimationUsingKeyFrames>
                                         <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)">
-                                            <LinearDoubleKeyFrame KeyTime="0" Value="0" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15" Value="20" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25" Value="0" />
+                                                                       Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)">
+                                            <LinearDoubleKeyFrame KeyTime="0"
+                                                                  Value="0" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15"
+                                                                  Value="20" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25"
+                                                                  Value="0" />
                                         </DoubleAnimationUsingKeyFrames>
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
-                                                         Duration="0:0:0.2" From="0" To="1" />
+                                                         From="0"
+                                                         To="1"
+                                                         Duration="0:0:0.2" />
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
-                                                         Duration="0:0:0.2" To="1" />
+                                                         To="1"
+                                                         Duration="0:0:0.2" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="VisibleDown">
                                     <Storyboard>
                                         <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                         Storyboard.TargetProperty="(UIElement.Opacity)">
-                                            <LinearDoubleKeyFrame KeyTime="0" Value="0" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15" Value="0" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25" Value="1" />
+                                                                       Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <LinearDoubleKeyFrame KeyTime="0"
+                                                                  Value="0" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15"
+                                                                  Value="0" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25"
+                                                                  Value="1" />
                                         </DoubleAnimationUsingKeyFrames>
                                         <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)">
-                                            <LinearDoubleKeyFrame KeyTime="0" Value="0" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15" Value="20" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25" Value="0" />
+                                                                       Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)">
+                                            <LinearDoubleKeyFrame KeyTime="0"
+                                                                  Value="0" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15"
+                                                                  Value="20" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25"
+                                                                  Value="0" />
                                         </DoubleAnimationUsingKeyFrames>
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
-                                                         Duration="0:0:0.2" To="1" />
+                                                         To="1"
+                                                         Duration="0:0:0.2" />
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
-                                                         Duration="0:0:0.2" From="0" To="1" />
+                                                         From="0"
+                                                         To="1"
+                                                         Duration="0:0:0.2" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="VisibleRight">
@@ -366,23 +474,32 @@
                                     </VisualState.Setters>
                                     <Storyboard>
                                         <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                         Storyboard.TargetProperty="(UIElement.Opacity)">
-                                            <LinearDoubleKeyFrame KeyTime="0" Value="0" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15" Value="0" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25" Value="1" />
+                                                                       Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <LinearDoubleKeyFrame KeyTime="0"
+                                                                  Value="0" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15"
+                                                                  Value="0" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25"
+                                                                  Value="1" />
                                         </DoubleAnimationUsingKeyFrames>
                                         <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)">
-                                            <LinearDoubleKeyFrame KeyTime="0" Value="0" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15" Value="20" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25" Value="0" />
+                                                                       Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)">
+                                            <LinearDoubleKeyFrame KeyTime="0"
+                                                                  Value="0" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15"
+                                                                  Value="20" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25"
+                                                                  Value="0" />
                                         </DoubleAnimationUsingKeyFrames>
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
-                                                         Duration="0:0:0.2" From="0" To="1" />
+                                                         From="0"
+                                                         To="1"
+                                                         Duration="0:0:0.2" />
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
-                                                         Duration="0:0:0.2" To="1" />
+                                                         To="1"
+                                                         Duration="0:0:0.2" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="VisibleUp">
@@ -406,23 +523,32 @@
                                     </VisualState.Setters>
                                     <Storyboard>
                                         <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                         Storyboard.TargetProperty="(UIElement.Opacity)">
-                                            <LinearDoubleKeyFrame KeyTime="0" Value="0" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15" Value="0" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25" Value="1" />
+                                                                       Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <LinearDoubleKeyFrame KeyTime="0"
+                                                                  Value="0" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15"
+                                                                  Value="0" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25"
+                                                                  Value="1" />
                                         </DoubleAnimationUsingKeyFrames>
                                         <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)">
-                                            <LinearDoubleKeyFrame KeyTime="0" Value="0" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15" Value="20" />
-                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25" Value="0" />
+                                                                       Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)">
+                                            <LinearDoubleKeyFrame KeyTime="0"
+                                                                  Value="0" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.15"
+                                                                  Value="20" />
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.25"
+                                                                  Value="0" />
                                         </DoubleAnimationUsingKeyFrames>
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
-                                                         Duration="0:0:0.2" To="1" />
+                                                         To="1"
+                                                         Duration="0:0:0.2" />
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
-                                                         Duration="0:0:0.2" From="0" To="1" />
+                                                         From="0"
+                                                         To="1"
+                                                         Duration="0:0:0.2" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="CollapsedLeft">
@@ -448,16 +574,21 @@
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetName="ContentPresenter"
                                                          Storyboard.TargetProperty="(UIElement.Opacity)"
-                                                         Duration="0:0:0.15" From="1" To="0" />
+                                                         From="1"
+                                                         To="0"
+                                                         Duration="0:0:0.15" />
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
-                                                         Duration="0:0:0.15" To="0" />
+                                                         To="0"
+                                                         Duration="0:0:0.15" />
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
-                                                         Duration="0:0:0.15" To="1" />
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_MainContent" 
+                                                         To="1"
+                                                         Duration="0:0:0.15" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_MainContent"
                                                                        Storyboard.TargetProperty="(UIElement.Visibility)">
-                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.15" Value="Collapsed"/>
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.15"
+                                                                    Value="Collapsed" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
@@ -468,16 +599,22 @@
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetName="ContentPresenter"
                                                          Storyboard.TargetProperty="(UIElement.Opacity)"
-                                                         Duration="0:0:0.15" From="1" To="0" />
+                                                         From="1"
+                                                         To="0"
+                                                         Duration="0:0:0.15" />
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
-                                                         Duration="0:0:0.15" To="1" />
+                                                         To="1"
+                                                         Duration="0:0:0.15" />
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
-                                                         Duration="0:0:0.15" From="1" To="0" />
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_MainContent" 
+                                                         From="1"
+                                                         To="0"
+                                                         Duration="0:0:0.15" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_MainContent"
                                                                        Storyboard.TargetProperty="(UIElement.Visibility)">
-                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.15" Value="Collapsed"/>
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.15"
+                                                                    Value="Collapsed" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
@@ -501,16 +638,21 @@
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetName="ContentPresenter"
                                                          Storyboard.TargetProperty="(UIElement.Opacity)"
-                                                         Duration="0:0:0.15" From="1" To="0" />
+                                                         From="1"
+                                                         To="0"
+                                                         Duration="0:0:0.15" />
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
-                                                         Duration="0:0:0.15" To="0" />
+                                                         To="0"
+                                                         Duration="0:0:0.15" />
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
-                                                         Duration="0:0:0.15" To="1" />
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_MainContent" 
+                                                         To="1"
+                                                         Duration="0:0:0.15" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_MainContent"
                                                                        Storyboard.TargetProperty="(UIElement.Visibility)">
-                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.15" Value="Collapsed"/>
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.15"
+                                                                    Value="Collapsed" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
@@ -537,78 +679,27 @@
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetName="ContentPresenter"
                                                          Storyboard.TargetProperty="(UIElement.Opacity)"
-                                                         Duration="0:0:0.15" From="1" To="0" />
+                                                         From="1"
+                                                         To="0"
+                                                         Duration="0:0:0.15" />
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
-                                                         Duration="0:0:0.15" To="1" />
+                                                         To="1"
+                                                         Duration="0:0:0.15" />
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
-                                                         Duration="0:0:0.15" From="1" To="0" />
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_MainContent" 
+                                                         From="1"
+                                                         To="0"
+                                                         Duration="0:0:0.15" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_MainContent"
                                                                        Storyboard.TargetProperty="(UIElement.Visibility)">
-                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.15" Value="Collapsed"/>
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.15"
+                                                                    Value="Collapsed" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Grid x:Name="PART_RootGrid" Background="{TemplateBinding Background}">
-                            <Grid.RowDefinitions>
-                                <RowDefinition x:Name="RowOne" Height="Auto" />
-                                <RowDefinition x:Name="RowTwo" Height="*" />
-                            </Grid.RowDefinitions>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="ColumnOne" Width="Auto" />
-                                <ColumnDefinition x:Name="ColumnTwo" Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <ContentControl Grid.Row="1" Grid.RowSpan="1" Grid.Column="0" Grid.ColumnSpan="2"
-                                            x:Name="PART_ContentOverlay"
-                                            Content="{TemplateBinding ContentOverlay}"
-                                            HorizontalAlignment="Stretch"
-                                            HorizontalContentAlignment="Stretch"
-                                            VerticalAlignment="Stretch"
-                                            VerticalContentAlignment="Stretch">
-                                <ContentControl.RenderTransform>
-                                    <ScaleTransform />
-                                </ContentControl.RenderTransform>
-                            </ContentControl>
-                            <Grid Grid.Row="1" 
-                                  Grid.RowSpan="1" 
-                                  Grid.Column="0" 
-                                  Grid.ColumnSpan="2"
-                                  x:Name="PART_MainContent"
-                                  Background="{TemplateBinding Background}">
-                                <ContentPresenter x:Name="ContentPresenter" Opacity="0"
-                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                  HorizontalContentAlignment="Stretch"
-                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  VerticalContentAlignment="Stretch">
-                                    <ContentPresenter.RenderTransform>
-                                        <TranslateTransform Y="20"/>
-                                    </ContentPresenter.RenderTransform>
-                                </ContentPresenter>
-                                <Grid.RenderTransform>
-                                    <ScaleTransform />
-                                </Grid.RenderTransform>
-                            </Grid>
-                            <controls:LayoutTransformControl Grid.Row="0" Grid.RowSpan="1" Grid.Column="0" Grid.ColumnSpan="2"
-                                                             x:Name="PART_LayoutTransformer"
-                                                             RenderTransformOrigin="0.5,0.5">
-                                <controls:LayoutTransformControl.Transform>
-                                    <RotateTransform x:Name="RotateLayoutTransform" Angle="0" />
-                                </controls:LayoutTransformControl.Transform>
-                                <ToggleButton x:Name="PART_ExpanderToggleButton" 
-                                              TabIndex="0"
-                                              AutomationProperties.Name="Expand"
-                                              Style="{TemplateBinding HeaderStyle}" 
-                                              Foreground="{TemplateBinding Foreground}"
-                                              ContentTemplate="{TemplateBinding HeaderTemplate}" 
-                                              Content="{TemplateBinding Header}" 
-                                              IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                              MinWidth="40"
-                                              MinHeight="40" />
-                            </controls:LayoutTransformControl>
-                        </Grid>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.xaml
@@ -1,16 +1,42 @@
-﻿<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls"
-    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
-    xmlns:contract5NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:contract5NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)"
+                    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
+                    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ms-appx:///Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/MSEdgeNotificationStyle.xaml" />
         <ResourceDictionary Source="ms-appx:///Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/Styles/VSCodeNotificationStyle.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style TargetType="local:InAppNotification" x:Key="BaseInAppNotificationsStyle">
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <contract5Present:AcrylicBrush x:Key="InAppNotificationAcrylicBackgroundBrush"
+                                           BackgroundSource="Backdrop"
+                                           FallbackColor="{ThemeResource SystemChromeMediumLowColor}"
+                                           TintColor="{ThemeResource SystemChromeMediumLowColor}"
+                                           TintOpacity="0.8" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="HighContrast">
+            <contract5Present:AcrylicBrush x:Key="InAppNotificationAcrylicBackgroundBrush"
+                                           BackgroundSource="Backdrop"
+                                           FallbackColor="{ThemeResource SystemColorButtonFaceColor}"
+                                           TintColor="{ThemeResource SystemColorButtonFaceColor}"
+                                           TintOpacity="0.8" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="Light">
+            <contract5Present:AcrylicBrush x:Key="InAppNotificationAcrylicBackgroundBrush"
+                                           BackgroundSource="Backdrop"
+                                           FallbackColor="{ThemeResource SystemChromeMediumLowColor}"
+                                           TintColor="{ThemeResource SystemChromeMediumLowColor}"
+                                           TintOpacity="0.8" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+
+    <Style x:Key="BaseInAppNotificationsStyle"
+           TargetType="local:InAppNotification">
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumBrush}" />
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
@@ -31,18 +57,13 @@
         <Setter Property="Template" Value="{StaticResource MSEdgeNotificationTemplate}" />
     </Style>
 
-    <contract5NotPresent:Style TargetType="local:InAppNotification" BasedOn="{StaticResource BaseInAppNotificationsStyle}">
+    <contract5NotPresent:Style BasedOn="{StaticResource BaseInAppNotificationsStyle}"
+                               TargetType="local:InAppNotification">
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}" />
     </contract5NotPresent:Style>
 
-    <contract5Present:Style TargetType="local:InAppNotification" BasedOn="{StaticResource BaseInAppNotificationsStyle}">
-        <Setter Property="Background">
-            <Setter.Value>
-                <AcrylicBrush BackgroundSource="Backdrop" 
-                              TintColor="{StaticResource SystemChromeMediumLowColor}" 
-                              TintOpacity="0.8"
-                              FallbackColor="{StaticResource SystemChromeMediumLowColor}" />
-            </Setter.Value>
-        </Setter>
+    <contract5Present:Style BasedOn="{StaticResource BaseInAppNotificationsStyle}"
+                            TargetType="local:InAppNotification">
+        <Setter Property="Background" Value="{ThemeResource InAppNotificationAcrylicBackgroundBrush}" />
     </contract5Present:Style>
 </ResourceDictionary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Menu/Menu.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Menu/Menu.xaml
@@ -1,11 +1,38 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:contract5NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)"
+                    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
                     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
-                    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls"
-    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
-    xmlns:contract5NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)">
+                    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
-    <Style TargetType="MenuFlyoutPresenter" x:Key="BaseMenuFlyoutStyle">
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <contract5Present:AcrylicBrush x:Key="MenuFlyoutAcrylicBackgroundBrush"
+                                           BackgroundSource="Backdrop"
+                                           FallbackColor="{ThemeResource SystemChromeMediumLowColor}"
+                                           TintColor="{ThemeResource SystemChromeMediumLowColor}"
+                                           TintOpacity="0.8" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="HighContrast">
+            <contract5Present:AcrylicBrush x:Key="MenuFlyoutAcrylicBackgroundBrush"
+                                           BackgroundSource="Backdrop"
+                                           FallbackColor="{ThemeResource SystemColorButtonFaceColor}"
+                                           TintColor="{ThemeResource SystemColorButtonFaceColor}"
+                                           TintOpacity="0.8" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="Light">
+            <contract5Present:AcrylicBrush x:Key="MenuFlyoutAcrylicBackgroundBrush"
+                                           BackgroundSource="Backdrop"
+                                           FallbackColor="{ThemeResource SystemChromeMediumLowColor}"
+                                           TintColor="{ThemeResource SystemChromeMediumLowColor}"
+                                           TintOpacity="0.8" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+
+    <Style x:Key="BaseMenuFlyoutStyle"
+           TargetType="MenuFlyoutPresenter">
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundChromeHighBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Padding" Value="{ThemeResource MenuFlyoutPresenterThemePadding}" />
@@ -18,47 +45,44 @@
         <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
         <Setter Property="MinWidth" Value="136" />
         <Setter Property="MaxWidth" Value="465" />
-        <Setter Property="MinHeight" Value="{ThemeResource MenuFlyoutThemeMinHeight}"/>
+        <Setter Property="MinHeight" Value="{ThemeResource MenuFlyoutThemeMinHeight}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="MenuFlyoutPresenter">
                     <Grid Background="{TemplateBinding Background}">
                         <ScrollViewer x:Name="MenuFlyoutPresenterScrollViewer"
-                            Padding="{TemplateBinding Padding}"
-                            Margin="{TemplateBinding BorderThickness}"
-                            MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.FlyoutContentMinWidth}"
-                            HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
-                            HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                            VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
-                            VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                            IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
-                            IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
-                            ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
-                            AutomationProperties.AccessibilityView="Raw">
+                                      MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.FlyoutContentMinWidth}"
+                                      Margin="{TemplateBinding BorderThickness}"
+                                      Padding="{TemplateBinding Padding}"
+                                      AutomationProperties.AccessibilityView="Raw"
+                                      HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                      HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                                      IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+                                      IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                      VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+                                      ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}">
                             <ItemsPresenter Margin="0" />
                         </ScrollViewer>
                         <Border x:Name="MenuFlyoutPresenterBorder"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"/>
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
-    <contract5NotPresent:Style TargetType="MenuFlyoutPresenter" BasedOn="{StaticResource BaseMenuFlyoutStyle}" x:Key="MenuFlyoutStyle">
-        <Setter Property="Background" Value="{StaticResource SystemControlBackgroundChromeMediumLowBrush}" />
+    <contract5NotPresent:Style x:Key="MenuFlyoutStyle"
+                               BasedOn="{StaticResource BaseMenuFlyoutStyle}"
+                               TargetType="MenuFlyoutPresenter">
+        <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}" />
     </contract5NotPresent:Style>
 
-    <contract5Present:Style TargetType="MenuFlyoutPresenter" BasedOn="{StaticResource BaseMenuFlyoutStyle}" x:Key="MenuFlyoutStyle">
-        <Setter Property="Background">
-            <Setter.Value>
-                <AcrylicBrush BackgroundSource="Backdrop" 
-                              TintColor="{StaticResource SystemChromeMediumLowColor}" 
-                              TintOpacity="0.8" 
-                              FallbackColor="{StaticResource SystemChromeMediumLowColor}" />
-            </Setter.Value>
-        </Setter>
+    <contract5Present:Style x:Key="MenuFlyoutStyle"
+                            BasedOn="{StaticResource BaseMenuFlyoutStyle}"
+                            TargetType="MenuFlyoutPresenter">
+        <Setter Property="Background" Value="{ThemeResource MenuFlyoutAcrylicBackgroundBrush}" />
     </contract5Present:Style>
 
     <Style TargetType="local:Menu">
@@ -90,12 +114,14 @@
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundTransparentBrush}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="UseSystemFocusVisuals" Value="True" />
-        <Setter Property="Padding" Value="12, 0" />
+        <Setter Property="Padding" Value="12,0" />
         <Setter Property="Height" Value="40" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:MenuItem">
                     <Button x:Name="FlyoutButton"
+                            Height="{TemplateBinding Height}"
+                            Padding="{TemplateBinding Padding}"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
@@ -107,9 +133,7 @@
                             FontStyle="{TemplateBinding FontStyle}"
                             FontWeight="{TemplateBinding FontWeight}"
                             Foreground="{TemplateBinding Foreground}"
-                            IsTabStop="False"
-                            Height="{TemplateBinding Height}"
-                            Padding="{TemplateBinding Padding}">
+                            IsTabStop="False">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal">


### PR DESCRIPTION
Issue: #2276 

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
Code style update (formatting)
Sample app changes


## What is the current behavior?
These controls won't change the background color while the app its running.
- InAppNotification
- Expander
- Menu

## What is the new behavior?
The above controls will now change the background color while the app is running.

- Expander
  - Changed from a custom brush to SystemControlPageBackgroundChromeLowBrush
  - Updated the Sample app text color to be a ThemeResource instead of StaticResource
- InAppNotification and Menu
  - Updated the custom acrylic brush to have a high contrast version, when in dark/light mode it uses the existing SystemChromeMediumLowColor, while in high contrast it uses SystemColorButtonFaceColor
- XamlStyler reformatted these pages, my only changes are the ones mentioned above

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
- [x] Contains **NO** breaking changes

## Other Info
Some pretty bad existing issues in high contrast for the toggle button portion of the expander control exist, will try to tackle later