### PR TITLE
Use WebViewControlHost.IsSupported to avoid loading APIs on downlevel OS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,13 +40,12 @@
         
         When changing this value, ensure the SDK is installed with the build process.
         Need to check several files:
-          - /.vsts-ci.yml
-          - /.vsts-pr.yml
+          - /azure-pipelines.yml
 
         This also needs to be installed on your local machine. Can do this with PowerShell:
-          ./build/Install-WindowsSDKISO.ps1 17713
+          ./build/Install-WindowsSDKISO.ps1 17758
         -->
-        <TargetPlatformVersion>10.0.17733.0</TargetPlatformVersion>
+        <TargetPlatformVersion>10.0.17758.0</TargetPlatformVersion>
         <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
 
         <!-- Compiler -->

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Wpf.UI.Controls.WebView/WebViewCompatible.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Wpf.UI.Controls.WebView/WebViewCompatible.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
         public WebViewCompatible()
             : base()
         {
-            if (Windows.Foundation.Metadata.ApiInformation.IsTypePresent("Windows.Web.UI.Interop.WebViewControl"))
+            if (WebViewControlHost.IsSupported)
             {
                 _implementation = new WebViewCompatibilityAdapter();
             }
@@ -46,7 +46,7 @@ namespace Microsoft.Toolkit.Wpf.UI.Controls
             Dispose(false);
         }
 
-        public static bool IsLegacy { get; } = !Windows.Foundation.Metadata.ApiInformation.IsTypePresent("Windows.Web.UI.Interop.WebViewControl");
+        public static bool IsLegacy { get; } = !WebViewControlHost.IsSupported;
 
         private IWebViewCompatibleAdapter _implementation;
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ steps:
   displayName: Set Version
   condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
       
-- powershell: .\build\Install-WindowsSdkISO.ps1 17733
+- powershell: .\build\Install-WindowsSdkISO.ps1 17758
   displayName: Insider SDK
 
 - powershell: .\build\build.ps1 -target=Package


### PR DESCRIPTION
Issue: Fixes #2477
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Throws on Win7

## What is the new behavior?
Works on Win7

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
