### PR TITLE
Fix initial size for WPF WebView.

### DIFF
--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/Win32/DpiHelper.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/Win32/DpiHelper.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Runtime.InteropServices;
 using Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32;
 
 namespace Microsoft.Toolkit.Win32.UI.Controls.Interop
@@ -13,103 +11,6 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop
     /// </summary>
     internal static class DpiHelper
     {
-        internal const double LogicalDpi = 96d;
-
-        // The primary screen's (device) current DPI
-        private static double _deviceDpi = LogicalDpi;
-
-        private static bool _enableHighDpi;
-        private static bool _isInitialized;
-        private static bool _enableDpiChangedMessageHandling;
-        private static double _logicalToDeviceUnitsScalingFactor;
-
-        internal static int DeviceDpi
-        {
-            get
-            {
-                Initialize();
-                return (int)_deviceDpi;
-            }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether to enable processing of WM_DPICHANGED and related messages
-        /// </summary>
-        internal static bool EnableDpiChangedMessageHandling
-        {
-            get
-            {
-                Initialize();
-                if (_enableDpiChangedMessageHandling)
-                {
-                    // We can't cache this because different top level windows can have different DPI awareness contexts
-                    var dpiAwareness = NativeMethods.GetThreadDpiAwarenessContext();
-                    return NativeMethods.AreDpiAwarenessContextsEqual(
-                        dpiAwareness,
-                        NativeMethods.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-                }
-
-                return false;
-            }
-        }
-
-        internal static bool IsPerMonitorDpiAware
-        {
-            get
-            {
-                Initialize();
-                if (_enableHighDpi)
-                {
-                    var result = UnsafeNativeMethods.GetProcessDpiAwareness(
-                        IntPtr.Zero, // Current process
-                        out PROCESS_DPI_AWARENESS value);
-
-                    if (result != 0)
-                    {
-                        // Some sort of error
-                        return false;
-                    }
-
-                    return value == PROCESS_DPI_AWARENESS.PROCESS_PER_MONITOR_DPI_AWARE;
-                }
-
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether scaling is required when converting between logical-device units, if the application opted in the automatic scaling
-        /// </summary>
-        /// <value><see langword="true" /> if scaling is required; otherwise, <see langword="false" />.</value>
-        internal static bool IsScalingRequired
-        {
-            get
-            {
-                Initialize();
-#pragma warning disable RECS0018 // Comparison of floating point numbers with equality operator
-                return _deviceDpi != LogicalDpi;
-#pragma warning restore RECS0018 // Comparison of floating point numbers with equality operator
-            }
-        }
-
-        private static double LogicalToDeviceUnitsScalingFactor
-        {
-            get
-            {
-#pragma warning disable RECS0018 // Comparison of floating point numbers with equality operator
-                if (_logicalToDeviceUnitsScalingFactor == 0d)
-#pragma warning restore RECS0018 // Comparison of floating point numbers with equality operator
-                {
-                    Initialize();
-                    _logicalToDeviceUnitsScalingFactor = _deviceDpi / LogicalDpi;
-                }
-
-                return _logicalToDeviceUnitsScalingFactor;
-            }
-        }
-
-        public static int Scale(double value, double scalingFactor) => (int)Math.Round(scalingFactor * value);
-
         // Sets DPI awareness for the process. Returns true if DPI awareness is successfully set; otherwise, false.
         public static bool SetPerMonitorDpiAwareness()
         {
@@ -121,53 +22,6 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop
             }
 
             return false;
-        }
-
-        internal static void Initialize()
-        {
-            if (!_isInitialized)
-            {
-                if (OSVersionHelper.IsWindows10AnniversaryOrGreater)
-                {
-                    // Primary screen DPI might be 96, but other screens may not be
-                    _enableDpiChangedMessageHandling = true;
-                    _enableHighDpi = true;
-                }
-
-                if (_enableHighDpi)
-                {
-                    _deviceDpi = GetSystemDpi();
-                }
-
-                _isInitialized = true;
-            }
-        }
-
-        // Transforms a horizontal or vertical integer coordinate from logical to device units
-        // by scaling it up  for current DPI and rounding to nearest integer value
-        internal static int LogicalToDeviceUnits(double value, int devicePixels = 0)
-        {
-            if (devicePixels == 0)
-            {
-                return (int)Math.Round(LogicalToDeviceUnitsScalingFactor * value);
-            }
-
-            double scalingFactor = devicePixels / LogicalDpi;
-            return Scale(value, scalingFactor);
-        }
-
-        // Returns the system DPI
-        private static double GetSystemDpi()
-        {
-            var newDpiX = 0;
-            var hDC = UnsafeNativeMethods.GetDC(NativeMethods.NullHandleRef);
-            if (hDC != IntPtr.Zero)
-            {
-                newDpiX = UnsafeNativeMethods.GetDeviceCaps(new HandleRef(null, hDC), NativeMethods.LOGPIXELSX);
-                UnsafeNativeMethods.ReleaseDC(NativeMethods.NullHandleRef, new HandleRef(null, hDC));
-            }
-
-            return newDpiX;
         }
     }
 }

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/Win32/UnsafeNativeMethods.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/Win32/UnsafeNativeMethods.cs
@@ -5,7 +5,6 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using System.Security;
 using System.Text;
 
@@ -14,46 +13,6 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32
     internal static class UnsafeNativeMethods
     {
         // Critical: P-Invokes
-        [SecurityCritical]
-        [DllImport(ExternDll.ShCore, SetLastError = true)]
-        public static extern int GetProcessDpiAwareness(
-            IntPtr hprocess,
-            out PROCESS_DPI_AWARENESS value);
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, EntryPoint = "GetDC", CharSet = CharSet.Auto)]
-        [ResourceExposure(ResourceScope.Process)]
-        private static extern IntPtr IntGetDC(HandleRef hWnd);
-
-        [ResourceExposure(ResourceScope.Process)]
-        [ResourceConsumption(ResourceScope.Process)]
-        public static IntPtr GetDC(HandleRef hWnd)
-        {
-            // REVIEW: We can leak this handle unless ReleaseDC is called
-            return IntGetDC(hWnd);
-        }
-
-        [DllImport(ExternDll.User32, ExactSpelling = true, EntryPoint = "ReleaseDC", CharSet = CharSet.Auto)]
-        [ResourceExposure(ResourceScope.None)]
-        private static extern int IntReleaseDC(HandleRef hWnd, HandleRef hDC);
-
-        public static int ReleaseDC(HandleRef hWnd, HandleRef hDC)
-        {
-            return IntReleaseDC(hWnd, hDC);
-        }
-
-        [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
-        [ResourceExposure(ResourceScope.None)]
-        public static extern int GetDeviceCaps(HandleRef hDC, int nIndex);
-
-        // Critical: P-Invokes
-        [SecurityCritical]
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        internal static extern bool GetClientRect(HandleRef hWnd, [In, Out] ref RECT rect);
-
-        // Critical: P-Invokes
-        [SecurityCritical]
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        internal static extern IntPtr GetParent(HandleRef hWnd);
 
         // Critical: This code elevates to unmanaged code permission
         [SecurityCritical]
@@ -98,15 +57,5 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32
         [SecurityCritical]
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern IntPtr GetFocus();
-
-        // Critical: P-Invokes
-        [SecurityCritical]
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern int MapWindowPoints(HandleRef hWndFrom, HandleRef hWndTo, [In, Out] ref RECT rect, int cPoints);
-
-        // Critical: P-Invokes
-        [SecurityCritical]
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
-        public static extern bool GetWindowRect(HandleRef hWnd, [In, Out] ref RECT rect);
     }
 }

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebView.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebView.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         private ManualResetEvent _initializationComplete;
 
         [SecuritySafeCritical]
-        [SuppressMessage("Microsoft.Design", "CA1065", Justification ="Exceptions thrown to fail as fast as possible.")]
+        [SuppressMessage("Microsoft.Design", "CA1065", Justification = "Exceptions thrown to fail as fast as possible.")]
         static WebView()
         {
 #pragma warning disable 1065
@@ -728,7 +728,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
                     if (_webViewControl == null)
                     {
                         var handle = ChildWindow.Handle;
-                        var bounds = new Windows.Foundation.Rect(0, 0, RenderSize.Width, RenderSize.Height);
+                        var bounds = new Windows.Foundation.Rect(0, 0, RenderSize.Width * DpiScale.DpiScaleX, RenderSize.Height * DpiScale.DpiScaleY);
 
                         _webViewControl = await _process.CreateWebViewControlHostAsync(handle, bounds).ConfigureAwait(false);
                     }
@@ -805,7 +805,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         /// <inheritdoc />
         protected override void UpdateBounds(Rect bounds)
         {
-            UpdateBounds((int)bounds.X, (int)bounds.Y, (int)bounds.Width, (int)bounds.Height);
+            UpdateBounds(bounds.X, bounds.Y, bounds.Width, bounds.Height);
         }
 
         private static void OnIsEnabledInvalidated(WebView webView)
@@ -1140,26 +1140,23 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
             _webViewControl.UnviewableContentIdentified -= OnUnviewableContentIdentified;
         }
 
-        private void UpdateBounds(int x, int y, int width, int height)
+        private void UpdateBounds(double x, double y, double width, double height)
         {
 #if DEBUG_LAYOUT
             Debug.WriteLine($"{Name}::{nameof(UpdateBounds)}");
             Debug.Indent();
-            Debug.WriteLine($"oldBounds={{x={x} y={y} width={width} height={height}}}");
+            Debug.WriteLine($"oldBounds={{x={x:F0} y={y:F0} width={width:F0} height={height:F0}}}");
 #endif
 
             // Update bounds here to ensure correct draw position
-            if (IsScalingRequired)
-            {
-                width = DpiHelper.LogicalToDeviceUnits(width, DeviceDpi);
-                height = DpiHelper.LogicalToDeviceUnits(height, DeviceDpi);
-            }
+            width *= DpiScale.DpiScaleX;
+            height *= DpiScale.DpiScaleY;
 
             // HACK: looks like the vertical pos is counted twice, giving a gap
             y = 0;
 
 #if DEBUG_LAYOUT
-            Debug.WriteLine($"newBounds={{x={x} y={y} width={width} height={height}}}");
+            Debug.WriteLine($"newBounds={{x={x:F0} y={y:F0} width={width:F0} height={height:F0}}}");
 #endif
             if (WebViewControlInitialized)
             {

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebViewHost.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebViewHost.cs
@@ -12,6 +12,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
+using System.Windows.Media;
 using Microsoft.Toolkit.Win32.UI.Controls.Interop;
 using Microsoft.Toolkit.Win32.UI.Controls.Interop.Win32;
 
@@ -43,11 +44,8 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         /// </summary>
         protected WebViewHost()
         {
-            DpiHelper.Initialize();
             DpiHelper.SetPerMonitorDpiAwareness();
-
-            // Get system DPI
-            DeviceDpi = DpiHelper.DeviceDpi;
+            DpiScale = VisualTreeHelper.GetDpi(this);
 
             DpiChanged += OnDpiChanged;
             SizeChanged += OnSizeChanged;
@@ -71,16 +69,23 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         protected HandleRef ChildWindow { get; private set; }
 
         /// <summary>
+        /// Gets the DPI information for which the <see cref="Visual"/> is measured and rendered.
+        /// </summary>
+        protected DpiScale DpiScale { get; private set; }
+
+        /// <summary>
         /// Gets the current DPI for this control
         /// </summary>
         /// <seealso cref="IsScalingRequired"/>
-        protected int DeviceDpi { get; private set; }
+        [Obsolete("This property is obsolete and will be removed in a future version. Use DpiScale instead.")]
+        protected int DeviceDpi => (int)DpiScale.PixelsPerInchX;
 
         /// <summary>
         /// Gets a value indicating whether scaling is required for the current DPI.
         /// </summary>
         /// <value><see langword="true"/> if scaling is required; otherwise, <see langword="false"/>.</value>
-        protected bool IsScalingRequired => DeviceDpi != DpiHelper.LogicalDpi;
+        [Obsolete("This property is obsolete and will be removed in a future version.")]
+        protected bool IsScalingRequired => DpiScale.DpiScaleX != 1 || DpiScale.DpiScaleY != 1;
 
         /// <summary>
         /// Gets the parent handle.
@@ -242,8 +247,9 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
 #if DEBUG_LAYOUT
             Debug.WriteLine("Old DPI: ({0}, {1}), New DPI: ({2}, {3})", e.OldDpi.DpiScaleX, e.OldDpi.DpiScaleY, e.NewDpi.DpiScaleX, e.NewDpi.DpiScaleY);
 #endif
-            Verify.AreEqual(DeviceDpi, e.OldDpi.PixelsPerInchX);
-            DeviceDpi = (int)e.NewDpi.PixelsPerInchX;
+            Verify.AreEqual(DpiScale.PixelsPerInchX, e.OldDpi.PixelsPerInchX);
+            Verify.AreEqual(DpiScale.PixelsPerInchY, e.OldDpi.PixelsPerInchY);
+            DpiScale = e.NewDpi;
         }
 
         private void OnSizeChanged(object o, SizeChangedEventArgs e)


### PR DESCRIPTION
Issue: #2076
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In high DPI scenarios initial size of HWND does not account for DPI scale. This is a port of the change submitted for 5.0

## What is the new behavior?
With DPI handled within the WebViewHost, DPIHelper no longer needs to retrieve DPI information for UI scaling. As a result, much of the class and underlying P/Invokes can be removed. Changes non-breaking: 
Marked existing properties as `Obsolete` on `WebViewHost`. Other changes to `DpiHelper`, `UnsafeNativeMethods`, and `WebView` are all internal, private, or only used by the modified code.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
Cherry picked from a5a1fdedcaa331bf6ec77f6f3c041bf285c192c0, 9ba76eab1b80890819c6cf38d604cd9adf356976, 82c0af2e7e74cd98cb401282b84685e8df559f6a, ccd8c4006355add93281567b0710ae2013a12ca1, 45f6cd2b5c888a2569f5e12dcea0a4c848860d78

See #2447, #2076

CC @huoyaoyuan