### PR TITLE
Change index of SetWindowLong() call to GWL_EXSTYLE to avoid crash in…

### DIFF
--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/Interop/Win32/NativeDefines.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/Interop/Win32/NativeDefines.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost.Interop.Win32
         // Window Styles
         public const uint WS_EX_CONTROLPARENT = 0x00010000;
         public const int GWL_STYLE = -16;
+        public const int GWL_EXSTYLE = -20;
 
         public static IntPtr HWND_TOP { get; } = IntPtr.Zero;
 

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Forms.UI.XamlHost/WindowsXamlHostBase.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Toolkit.Forms.UI.XamlHost
                 _xamlIslandWindowHandle = desktopWindowXamlSourceNative.WindowHandle;
 
                 // Set window style required by container control to support Focus
-                if (Interop.Win32.UnsafeNativeMethods.SetWindowLong(Handle, Interop.Win32.NativeDefines.GWL_STYLE, Interop.Win32.NativeDefines.WS_EX_CONTROLPARENT) == 0)
+                if (Interop.Win32.UnsafeNativeMethods.SetWindowLong(Handle, Interop.Win32.NativeDefines.GWL_EXSTYLE, Interop.Win32.NativeDefines.WS_EX_CONTROLPARENT) == 0)
                 {
                     throw new InvalidOperationException("WindowsXamlHostBase::OnHandleCreated: Failed to set WS_EX_CONTROLPARENT on control window.");
                 }


### PR DESCRIPTION
… Windows Forms XAML host

Issue: #

#2456

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?

Windows forms app containing a XAML host element crashes with exception InvalidOperationException in SetDesktopWindowXamlSourceWindowPos() when programmatically maximized.

## What is the new behavior?

The index parameter to the SetWindowLong() call is changed from GWL_STYLE to GWL_EXSTYLE to correspond with the WS_EX_CONTROLPARENT parameter. This seems to avoid the crash and also avoids an issue where the app hangs when it is defocused and focused again (maybe related to #2491 ?). 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
