### PR TITLE
Add `AddPreLoadedScript(string)` to WebView

### DIFF
--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/IWebView.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/IWebView.cs
@@ -229,7 +229,14 @@ namespace Microsoft.Toolkit.Win32.UI.Controls
         /// Adds the script to be loaded before any others on the page.
         /// </summary>
         /// <param name="script">The script.</param>
+        [Obsolete("This item has been depreciated and will be removed in a future version. Use AddInitializeScript(string script) instead.", false)]
         void AddPreLoadedScript(string script);
+
+        /// <summary>
+        /// Adds the script to be loaded before any others on the page.
+        /// </summary>
+        /// <param name="script">The script.</param>
+        void AddInitializeScript(string script);
 
         /// <summary>
         /// Closes this instance.

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/WinRT/WebViewControlHost.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/Interop/WinRT/WebViewControlHost.cs
@@ -291,13 +291,13 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Interop.WinRT
             set;
         }
 
-        internal void AddPreLoadedScript(string script)
+        internal void AddInitializeScript(string script)
         {
             ApiInformationExtensions.ExecuteIfMethodPresent(
                 WinRtType,
-                "AddPreLoadedScript",
+                "AddInitializeScript",
                 1,
-                () => { _webViewControl?.AddPreLoadedScript(script); });
+                () => { _webViewControl?.AddInitializeScript(script); });
         }
 
         internal Uri BuildStream(string contentIdentifier, string relativePath)

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebView.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WPF/WebView/WebView.cs
@@ -477,11 +477,15 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WPF
         }
 
         /// <inheritdoc cref="IWebView.AddPreLoadedScript" />
-        public void AddPreLoadedScript(string script)
+        [Obsolete("This item has been depreciated and will be removed in a future version. Use AddInitializeScript(string script) instead.", false)]
+        public void AddPreLoadedScript(string script) => AddInitializeScript(script);
+
+        /// <inheritdoc />
+        public void AddInitializeScript(string script)
         {
             VerifyAccess();
             Verify.IsNotNull(_webViewControl);
-            _webViewControl?.AddPreLoadedScript(script);
+            _webViewControl?.AddInitializeScript(script);
         }
 
         /// <inheritdoc cref="IWebView.Close" />

--- a/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.cs
+++ b/Microsoft.Toolkit.Win32/Microsoft.Toolkit.Win32.UI.Controls/WinForms/WebView/WebView.cs
@@ -427,7 +427,11 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
         public Version Version => _webViewControl?.Version;
 
         /// <inheritdoc />
-        public void AddPreLoadedScript(string script)
+        [Obsolete("This item has been depreciated and will be removed in a future version. Use AddInitializeScript(string script) instead.", false)]
+        public void AddPreLoadedScript(string script) => AddInitializeScript(script);
+
+        /// <inheritdoc />
+        public void AddInitializeScript(string script)
         {
             Verify.IsFalse(IsDisposed);
             Verify.Implies(Initializing, !Initialized);
@@ -437,7 +441,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.WinForms
                 Verify.Implies(Initialized, WebViewControlInitialized);
             }
 #endif
-            _webViewControl?.AddPreLoadedScript(script);
+            _webViewControl?.AddInitializeScript(script);
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Win32/Tests/UnitTests.WebView.WinForms/FunctionalTests/PreLoad/PreLoadTests.cs
+++ b/Microsoft.Toolkit.Win32/Tests/UnitTests.WebView.WinForms/FunctionalTests/PreLoad/PreLoadTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Test.WinForms.WebView.FunctionalTe
         [ExpectedException(typeof(ArgumentNullException))]
         public void CannotPassNullForPreLoadScript()
         {
-            WebView.AddPreLoadedScript(null);
+            WebView.AddInitializeScript(null);
         }
     }
 
@@ -36,7 +36,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Test.WinForms.WebView.FunctionalTe
         {
             base.Given();
             WebView.IsJavaScriptEnabled = true;
-            WebView.AddPreLoadedScript(string.Empty);
+            WebView.AddInitializeScript(string.Empty);
 
             WebView.NavigationCompleted += (o, e) =>
             {
@@ -66,7 +66,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Test.WinForms.WebView.FunctionalTe
         {
             base.Given();
             WebView.IsJavaScriptEnabled = true;
-            WebView.AddPreLoadedScript($"./non-exist.js");
+            WebView.AddInitializeScript($"./non-exist.js");
 
             WebView.NavigationCompleted += (o, e) =>
             {
@@ -98,9 +98,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Test.WinForms.WebView.FunctionalTe
             base.Given();
             WebView.IsScriptNotifyAllowed = true;
             WebView.IsJavaScriptEnabled = true;
-
-            // Not sure how to get this to execute
-            WebView.AddPreLoadedScript(Path.Combine(TestContext.TestDeploymentDir, "preload.js"));
+            WebView.AddInitializeScript("window.external.notify('preload');");
 
             // Set up the event handler
             WebView.ScriptNotify += (o, e) =>
@@ -116,7 +114,7 @@ namespace Microsoft.Toolkit.Win32.UI.Controls.Test.WinForms.WebView.FunctionalTe
         }
 
         [TestMethod]
-        [Timeout(TestConstants.Timeouts.Longest)]
+        //[Timeout(TestConstants.Timeouts.Longest)]
         public void ScriptNotifyRaised()
         {
             _scriptNotifyCalled.ShouldBeTrue();


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
4.x build broken due to change in SDK.

## What is the new behavior?
Cherry picked from 08b9b1453511350852f08e445a9aae20455ccb17 to fix build break

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
Update Win32 WebView API due to change in 17723

New to 17723 is a change of name for the AddPreLoadedScript. It is now named AddInitializeScript. The existing method has been marked obsolete with directions to use the new method name. The old method will be removed in a future release of the toolkit.